### PR TITLE
Fix Corsair headset stands and mouse pads.

### DIFF
--- a/Chromatics/DeviceInterfaces/CorsairInterface.cs
+++ b/Chromatics/DeviceInterfaces/CorsairInterface.cs
@@ -736,7 +736,7 @@ namespace Chromatics.DeviceInterfaces
         {
             if (pause) return;
 
-            if (_corsairDeviceStand && !string.IsNullOrEmpty(CueSDK.MousematSDK?.MousematDeviceInfo?.Model))
+            if (_corsairDeviceStand && !string.IsNullOrEmpty(CueSDK.HeadsetStandSDK?.HeadsetStandDeviceInfo?.Model))
                 if (_corsairkeyids.ContainsKey(region))
                     if (CueSDK.HeadsetStandSDK[_corsairkeyids[region]] != null)
                         _corsairStandIndvBrush.CorsairApplyMapKeyLighting(_corsairkeyids[region], col);


### PR DESCRIPTION
The ApplyMapStandLighting method was checking that a mousemat existed before actually trying to adjust the headset stand. This also fixes having a Corsair mouse pad installed, as it would succeed in the check and then try to adjust the nonexistent headset stand. So, if you had one but not the other, neither worked (and in fact the debug log got spammed from the NRE).