### PR TITLE
v4.0.154–4.0.156: Sentry triage + Dependabot rollup + Sharlayan bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Chromatics are documented here.
 
+## 4.0.156
+
+- Updated the FFXIV memory reader (Sharlayan) to the latest prerelease for improved compatibility with current game patches.
+
 ## 4.0.155
 
 - Updated underlying UI framework (Avalonia) and test tooling to the latest patch versions for improved stability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Chromatics are documented here.
 
+## 4.0.155
+
+- Updated underlying UI framework (Avalonia) and test tooling to the latest patch versions for improved stability.
+
 ## 4.0.154
 
 - Fixed an issue where Chromatics could close itself with a crash dialog if a connected device (Hue, OpenRGB, etc.) had a brief network hiccup. These transient errors are now ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Chromatics are documented here.
 
-## 4.0.28
+## 4.0.154
 
-_Release notes coming soon._
+- Fixed an issue where Chromatics could close itself with a crash dialog if a connected device (Hue, OpenRGB, etc.) had a brief network hiccup. These transient errors are now ignored.
+- Saving your layer setup is more reliable: if antivirus, OneDrive, or Dropbox briefly locks the file, Chromatics will retry rather than failing the save.
+- Quietened expected startup messages — if iCUE or OpenRGB isn't running, the app no longer treats it as a crash report.
+
+## 4.0.153
+
+Initial public release of Chromatics 4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,10 @@ All notable changes to Chromatics are documented here.
 
 ## 4.0.156
 
-- Updated the FFXIV memory reader (Sharlayan) to the latest prerelease for improved compatibility with current game patches.
-
-## 4.0.155
-
-- Updated underlying UI framework (Avalonia) and test tooling to the latest patch versions for improved stability.
-
-## 4.0.154
-
 - Fixed an issue where Chromatics could close itself with a crash dialog if a connected device (Hue, OpenRGB, etc.) had a brief network hiccup. These transient errors are now ignored.
 - Saving your layer setup is more reliable: if antivirus, OneDrive, or Dropbox briefly locks the file, Chromatics will retry rather than failing the save.
 - Quietened expected startup messages — if iCUE or OpenRGB isn't running, the app no longer treats it as a crash report.
+- Updated dependency libraries to latest version
 
 ## 4.0.153
 

--- a/Chromatics.DecoratorHarnessUI/Chromatics.DecoratorHarnessUI.csproj
+++ b/Chromatics.DecoratorHarnessUI/Chromatics.DecoratorHarnessUI.csproj
@@ -16,25 +16,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.1" />
+    <PackageReference Include="Avalonia" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Sharlayan">
-      <HintPath>..\Build Dependencies\Sharlayan\Sharlayan.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\Build Dependencies\Sharlayan\*.dll" Exclude="..\Build Dependencies\Sharlayan\Sharlayan.dll">
-      <Link>%(Filename)%(Extension)</Link>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Visible>false</Visible>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/Chromatics.Tests/Chromatics.Tests.csproj
+++ b/Chromatics.Tests/Chromatics.Tests.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Chromatics.Tests/Chromatics.Tests.csproj
+++ b/Chromatics.Tests/Chromatics.Tests.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Sharlayan" Version="9.0.22-prerelease.33" />
+    <PackageReference Include="Sharlayan" Version="9.0.24-prerelease.35" />
   </ItemGroup>
 
 </Project>

--- a/Chromatics/Chromatics.csproj
+++ b/Chromatics/Chromatics.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows7.0</TargetFramework>
     <StartupObject>Chromatics.Program</StartupObject>
-    <Version>4.0.154.0</Version>
+    <Version>4.0.155.0</Version>
     <Authors>Danielle Thompson</Authors>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Copyright>logicallysynced 2026</Copyright>
@@ -48,12 +48,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.1" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.1" />
+    <PackageReference Include="Avalonia" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.2" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.2" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageReference Include="Velopack" Version="0.0.1298" />
     <PackageReference Include="Sentry" Version="6.4.1" />

--- a/Chromatics/Chromatics.csproj
+++ b/Chromatics/Chromatics.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows7.0</TargetFramework>
     <StartupObject>Chromatics.Program</StartupObject>
-    <Version>4.0.153.0</Version>
+    <Version>4.0.154.0</Version>
     <Authors>Danielle Thompson</Authors>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Copyright>logicallysynced 2026</Copyright>

--- a/Chromatics/Chromatics.csproj
+++ b/Chromatics/Chromatics.csproj
@@ -4,7 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows7.0</TargetFramework>
     <StartupObject>Chromatics.Program</StartupObject>
-    <Version>4.0.155.0</Version>
+    <Version>4.0.156.0</Version>
     <Authors>Danielle Thompson</Authors>
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <Copyright>logicallysynced 2026</Copyright>
@@ -83,7 +83,7 @@
     <PackageReference Include="RGB.NET.HID" Version="3.2.0" />
     <PackageReference Include="RGB.NET.Layout" Version="3.2.0" />
     <PackageReference Include="RGB.NET.Presets" Version="3.2.0" />
-    <PackageReference Include="Sharlayan" Version="9.0.22-prerelease.33" />
+    <PackageReference Include="Sharlayan" Version="9.0.24-prerelease.35" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Chromatics/Core/Logger.cs
+++ b/Chromatics/Core/Logger.cs
@@ -34,7 +34,7 @@ namespace Chromatics.Core
             _logDirectory = directory;
         }
 
-        public static void WriteConsole(LoggerTypes type, string message)
+        public static void WriteConsole(LoggerTypes type, string message, bool forwardToSentry = true)
         {
             var color = (Color)EnumExtensions.GetAttribute<DefaultValueAttribute>(type).Value;
             var timestamp = DateTime.Now.ToString("MM-dd HH:mm:ss");
@@ -42,7 +42,8 @@ namespace Chromatics.Core
 
             AppendToVerboseLog($"[{timestamp}] [{type}] {message}");
 
-            ForwardToSentry(type, message);
+            if (forwardToSentry)
+                ForwardToSentry(type, message);
 
             lock (_gate)
             {

--- a/Chromatics/Core/RGBController.cs
+++ b/Chromatics/Core/RGBController.cs
@@ -99,8 +99,8 @@ namespace Chromatics.Core
                 var appSettings = AppSettings.GetSettings();
 
                 //Setup Exception Events
-                surfaceExceptionEventHandler = args_ => Logger.WriteConsole(Enums.LoggerTypes.Error, $"Device Error: {args_.Exception.Message}");
-                deviceExceptionEventHandler = (sender, e) => Logger.WriteConsole(Enums.LoggerTypes.Error, $"Device Error: {e.Exception.Message}");
+                surfaceExceptionEventHandler = args_ => Logger.WriteConsole(Enums.LoggerTypes.Error, $"Device Error: {args_.Exception.Message}", forwardToSentry: false);
+                deviceExceptionEventHandler = (sender, e) => Logger.WriteConsole(Enums.LoggerTypes.Error, $"Device Error: {e.Exception.Message}", forwardToSentry: false);
 
                 surface.Exception += surfaceExceptionEventHandler;
 

--- a/Chromatics/Core/SentryService.cs
+++ b/Chromatics/Core/SentryService.cs
@@ -4,6 +4,7 @@ using Sentry.Extensibility;
 using Sentry.Profiling;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 
 namespace Chromatics.Core
@@ -188,6 +189,18 @@ namespace Chromatics.Core
                 // drops everything else when consent is off.
                 o.SetBeforeSend((evt, _) =>
                 {
+                    // Drop unobserved-task SocketException noise (Hue/OpenRGB
+                    // shutdown, transient network resets) before consent gating.
+                    // These are auto-captured by Sentry's UnobservedTaskException
+                    // integration and would otherwise spam the Issues tab; our
+                    // own UnobservedTaskExceptionHandler already filters them
+                    // from the crash flow on the same criteria.
+                    if (evt.Exception != null && IsBenignBackgroundException(evt.Exception))
+                    {
+                        Logger.WriteVerbose($"[Sentry] BeforeSend dropped event {evt.EventId} — benign background exception ({evt.Exception.GetType().Name})");
+                        return null;
+                    }
+
                     var s = _settings;
                     bool consent = s == null || s.enableCrashReports;
                     bool isCrash = evt.Exception?.Data.Contains("Chromatics.HandledByCrashDialog") == true
@@ -571,6 +584,39 @@ namespace Chromatics.Core
             _sdkHandle?.Dispose();
             _initialized = false;
         }
+
+        // Mirror of Program.IsBenignBackgroundException — kept private to
+        // SentryService so the BeforeSend filter doesn't take a hard dep on
+        // Program. Both must agree on what's "benign" or events get dropped
+        // here while the crash flow still kills the app, or vice versa.
+        private static bool IsBenignBackgroundException(Exception ex)
+        {
+            if (ex is null) return false;
+            if (ex is AggregateException agg)
+            {
+                var flat = agg.Flatten();
+                return flat.InnerExceptions.Count > 0 && flat.InnerExceptions.All(IsBenignBackgroundException);
+            }
+            return ex switch
+            {
+                System.Net.Sockets.SocketException se => IsBenignSocketError(se.SocketErrorCode),
+                System.IO.IOException io => io.InnerException is System.Net.Sockets.SocketException ise && IsBenignSocketError(ise.SocketErrorCode),
+                ObjectDisposedException => true,
+                OperationCanceledException => true,
+                _ => false,
+            };
+        }
+
+        private static bool IsBenignSocketError(System.Net.Sockets.SocketError code) => code switch
+        {
+            System.Net.Sockets.SocketError.OperationAborted => true,
+            System.Net.Sockets.SocketError.ConnectionReset => true,
+            System.Net.Sockets.SocketError.ConnectionAborted => true,
+            System.Net.Sockets.SocketError.Interrupted => true,
+            System.Net.Sockets.SocketError.Shutdown => true,
+            System.Net.Sockets.SocketError.NetworkReset => true,
+            _ => false,
+        };
     }
 
     /// <summary>

--- a/Chromatics/Helpers/FileOperationsHelper.cs
+++ b/Chromatics/Helpers/FileOperationsHelper.cs
@@ -17,6 +17,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Serialization;
 using static System.Net.WebRequestMethods;
@@ -313,10 +314,37 @@ namespace Chromatics.Helpers
                     sw.Flush();
                 }
 
-                if (File.Exists(path))
-                    File.Replace(tmp, path, null);
-                else
-                    File.Move(tmp, path);
+                // File.Replace can throw "Unable to remove the file to be
+                // replaced" when AV / OneDrive / Dropbox is briefly holding
+                // the destination open. Retry with backoff before giving up.
+                ReplaceWithRetry(tmp, path);
+            }
+        }
+
+        private static void ReplaceWithRetry(string tmp, string path)
+        {
+            const int maxAttempts = 5;
+            int delayMs = 50;
+            for (int attempt = 1; ; attempt++)
+            {
+                try
+                {
+                    if (File.Exists(path))
+                        File.Replace(tmp, path, null);
+                    else
+                        File.Move(tmp, path);
+                    return;
+                }
+                catch (IOException) when (attempt < maxAttempts)
+                {
+                    Thread.Sleep(delayMs);
+                    delayMs *= 2;
+                }
+                catch (UnauthorizedAccessException) when (attempt < maxAttempts)
+                {
+                    Thread.Sleep(delayMs);
+                    delayMs *= 2;
+                }
             }
         }
 

--- a/Chromatics/Program.cs
+++ b/Chromatics/Program.cs
@@ -207,8 +207,47 @@ namespace Chromatics
             // UnobservedTaskExceptionIntegration captured the event but our
             // code did nothing to surface or terminate.
             e.SetObserved();
+
+            // Exception to that rule: socket aborts during shutdown (Hue
+            // entertainment client, OpenRGB TCP client, AutoUpdater HTTPS)
+            // surface as unobserved SocketException with WSAEINTR /
+            // WSAECONNABORTED / OperationAborted. They're cosmetic — the
+            // dependent task is already on its way out. Crashing the whole
+            // app for them spams users with the crash dialog.
+            if (IsBenignBackgroundException(e.Exception))
+                return;
+
             CrashHandler.HandleCrash(e.Exception);
         }
+
+        private static bool IsBenignBackgroundException(Exception ex)
+        {
+            if (ex is null) return false;
+            if (ex is AggregateException agg)
+            {
+                var flat = agg.Flatten();
+                return flat.InnerExceptions.Count > 0 && flat.InnerExceptions.All(IsBenignBackgroundException);
+            }
+            return ex switch
+            {
+                System.Net.Sockets.SocketException se => IsBenignSocketError(se.SocketErrorCode),
+                System.IO.IOException io => io.InnerException is System.Net.Sockets.SocketException ise && IsBenignSocketError(ise.SocketErrorCode),
+                ObjectDisposedException => true,
+                OperationCanceledException => true,
+                _ => false,
+            };
+        }
+
+        private static bool IsBenignSocketError(System.Net.Sockets.SocketError code) => code switch
+        {
+            System.Net.Sockets.SocketError.OperationAborted => true,
+            System.Net.Sockets.SocketError.ConnectionReset => true,
+            System.Net.Sockets.SocketError.ConnectionAborted => true,
+            System.Net.Sockets.SocketError.Interrupted => true,
+            System.Net.Sockets.SocketError.Shutdown => true,
+            System.Net.Sockets.SocketError.NetworkReset => true,
+            _ => false,
+        };
 
         private static bool ThereCanOnlyBeOne()
         {

--- a/Chromatics/obj/Chromatics.csproj.nuget.dgspec.json
+++ b/Chromatics/obj/Chromatics.csproj.nuget.dgspec.json
@@ -1,17 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {}
+    "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {}
   },
   "projects": {
-    "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {
-      "version": "4.0.154",
+    "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {
+      "version": "4.0.156",
       "restore": {
-        "projectUniqueName": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+        "projectUniqueName": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
         "projectName": "Chromatics",
-        "projectPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+        "projectPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
         "packagesPath": "C:\\Users\\Hanielle\\.nuget\\packages\\",
-        "outputPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
+        "outputPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
         "projectStyle": "PackageReference",
         "fallbackFolders": [
           "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -31,6 +31,7 @@
         },
         "frameworks": {
           "net10.0-windows7.0": {
+            "framework": "net10.0-windows7.0",
             "targetAlias": "net10.0-windows7.0",
             "projectReferences": {}
           }
@@ -49,6 +50,7 @@
       },
       "frameworks": {
         "net10.0-windows7.0": {
+          "framework": "net10.0-windows7.0",
           "targetAlias": "net10.0-windows7.0",
           "dependencies": {
             "Avalonia": {
@@ -173,7 +175,7 @@
             },
             "Sharlayan": {
               "target": "Package",
-              "version": "[9.0.22-prerelease.33, )"
+              "version": "[9.0.24-prerelease.35, )"
             },
             "System.Drawing.Common": {
               "target": "Package",

--- a/Chromatics/obj/Chromatics.csproj.nuget.dgspec.json
+++ b/Chromatics/obj/Chromatics.csproj.nuget.dgspec.json
@@ -5,7 +5,7 @@
   },
   "projects": {
     "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {
-      "version": "4.0.153",
+      "version": "4.0.154",
       "restore": {
         "projectUniqueName": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
         "projectName": "Chromatics",

--- a/Chromatics/obj/Chromatics.csproj.nuget.dgspec.json
+++ b/Chromatics/obj/Chromatics.csproj.nuget.dgspec.json
@@ -1,17 +1,17 @@
 {
   "format": 1,
   "restore": {
-    "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {}
+    "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {}
   },
   "projects": {
-    "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {
+    "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj": {
       "version": "4.0.154",
       "restore": {
-        "projectUniqueName": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+        "projectUniqueName": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
         "projectName": "Chromatics",
-        "projectPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+        "projectPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
         "packagesPath": "C:\\Users\\Hanielle\\.nuget\\packages\\",
-        "outputPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
+        "outputPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
         "projectStyle": "PackageReference",
         "fallbackFolders": [
           "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -31,7 +31,6 @@
         },
         "frameworks": {
           "net10.0-windows7.0": {
-            "framework": "net10.0-windows7.0",
             "targetAlias": "net10.0-windows7.0",
             "projectReferences": {}
           }
@@ -50,16 +49,15 @@
       },
       "frameworks": {
         "net10.0-windows7.0": {
-          "framework": "net10.0-windows7.0",
           "targetAlias": "net10.0-windows7.0",
           "dependencies": {
             "Avalonia": {
               "target": "Package",
-              "version": "[12.0.1, )"
+              "version": "[12.0.2, )"
             },
             "Avalonia.Controls.ColorPicker": {
               "target": "Package",
-              "version": "[12.0.1, )"
+              "version": "[12.0.2, )"
             },
             "Avalonia.Controls.DataGrid": {
               "target": "Package",
@@ -67,15 +65,15 @@
             },
             "Avalonia.Desktop": {
               "target": "Package",
-              "version": "[12.0.1, )"
+              "version": "[12.0.2, )"
             },
             "Avalonia.Fonts.Inter": {
               "target": "Package",
-              "version": "[12.0.1, )"
+              "version": "[12.0.2, )"
             },
             "Avalonia.Themes.Fluent": {
               "target": "Package",
-              "version": "[12.0.1, )"
+              "version": "[12.0.2, )"
             },
             "CommunityToolkit.Mvvm": {
               "target": "Package",
@@ -202,7 +200,7 @@
               "privateAssets": "all"
             }
           },
-          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\10.0.202/PortableRuntimeIdentifierGraph.json",
+          "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\10.0.203/PortableRuntimeIdentifierGraph.json",
           "packagesToPrune": {
             "Microsoft.CSharp": "(,4.7.32767]",
             "Microsoft.VisualBasic": "(,10.4.32767]",

--- a/Chromatics/obj/Chromatics.csproj.nuget.g.props
+++ b/Chromatics/obj/Chromatics.csproj.nuget.g.props
@@ -14,14 +14,14 @@
     <SourceRoot Include="C:\Program Files (x86)\Microsoft Visual Studio\Shared\NuGetPackages\" />
   </ItemGroup>
   <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
-    <Import Project="$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.3-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.props" Condition="Exists('$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.3-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.props')" />
+    <Import Project="$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.4-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.props" Condition="Exists('$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.4-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.props')" />
     <Import Project="$(NuGetPackageRoot)sentry\6.4.1\buildTransitive\Sentry.props" Condition="Exists('$(NuGetPackageRoot)sentry\6.4.1\buildTransitive\Sentry.props')" />
     <Import Project="$(NuGetPackageRoot)harfbuzzsharp.nativeassets.webassembly\8.3.1.3\buildTransitive\netstandard1.0\HarfBuzzSharp.NativeAssets.WebAssembly.props" Condition="Exists('$(NuGetPackageRoot)harfbuzzsharp.nativeassets.webassembly\8.3.1.3\buildTransitive\netstandard1.0\HarfBuzzSharp.NativeAssets.WebAssembly.props')" />
-    <Import Project="$(NuGetPackageRoot)avalonia\12.0.1\buildTransitive\Avalonia.props" Condition="Exists('$(NuGetPackageRoot)avalonia\12.0.1\buildTransitive\Avalonia.props')" />
+    <Import Project="$(NuGetPackageRoot)avalonia\12.0.2\buildTransitive\Avalonia.props" Condition="Exists('$(NuGetPackageRoot)avalonia\12.0.2\buildTransitive\Avalonia.props')" />
   </ImportGroup>
   <PropertyGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
     <PkgSentry Condition=" '$(PkgSentry)' == '' ">C:\Users\Hanielle\.nuget\packages\sentry\6.4.1</PkgSentry>
     <PkgAvalonia_BuildServices Condition=" '$(PkgAvalonia_BuildServices)' == '' ">C:\Users\Hanielle\.nuget\packages\avalonia.buildservices\11.3.2</PkgAvalonia_BuildServices>
-    <PkgAvalonia Condition=" '$(PkgAvalonia)' == '' ">C:\Users\Hanielle\.nuget\packages\avalonia\12.0.1</PkgAvalonia>
+    <PkgAvalonia Condition=" '$(PkgAvalonia)' == '' ">C:\Users\Hanielle\.nuget\packages\avalonia\12.0.2</PkgAvalonia>
   </PropertyGroup>
 </Project>

--- a/Chromatics/obj/Chromatics.csproj.nuget.g.targets
+++ b/Chromatics/obj/Chromatics.csproj.nuget.g.targets
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
-    <Import Project="$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.3-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.targets" Condition="Exists('$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.3-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.targets')" />
+    <Import Project="$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.4-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.targets" Condition="Exists('$(NuGetPackageRoot)skiasharp.nativeassets.webassembly\3.119.4-preview.1.1\buildTransitive\netstandard1.0\SkiaSharp.NativeAssets.WebAssembly.targets')" />
     <Import Project="$(NuGetPackageRoot)sentry\6.4.1\buildTransitive\Sentry.targets" Condition="Exists('$(NuGetPackageRoot)sentry\6.4.1\buildTransitive\Sentry.targets')" />
     <Import Project="$(NuGetPackageRoot)sentry.profiling\6.4.1\buildTransitive\Sentry.Profiling.targets" Condition="Exists('$(NuGetPackageRoot)sentry.profiling\6.4.1\buildTransitive\Sentry.Profiling.targets')" />
     <Import Project="$(NuGetPackageRoot)harfbuzzsharp.nativeassets.webassembly\8.3.1.3\buildTransitive\netstandard1.0\HarfBuzzSharp.NativeAssets.WebAssembly.targets" Condition="Exists('$(NuGetPackageRoot)harfbuzzsharp.nativeassets.webassembly\8.3.1.3\buildTransitive\netstandard1.0\HarfBuzzSharp.NativeAssets.WebAssembly.targets')" />
     <Import Project="$(NuGetPackageRoot)communitytoolkit.mvvm\8.4.2\buildTransitive\CommunityToolkit.Mvvm.targets" Condition="Exists('$(NuGetPackageRoot)communitytoolkit.mvvm\8.4.2\buildTransitive\CommunityToolkit.Mvvm.targets')" />
     <Import Project="$(NuGetPackageRoot)avalonia.buildservices\11.3.2\buildTransitive\Avalonia.BuildServices.targets" Condition="Exists('$(NuGetPackageRoot)avalonia.buildservices\11.3.2\buildTransitive\Avalonia.BuildServices.targets')" />
-    <Import Project="$(NuGetPackageRoot)avalonia\12.0.1\buildTransitive\Avalonia.targets" Condition="Exists('$(NuGetPackageRoot)avalonia\12.0.1\buildTransitive\Avalonia.targets')" />
+    <Import Project="$(NuGetPackageRoot)avalonia\12.0.2\buildTransitive\Avalonia.targets" Condition="Exists('$(NuGetPackageRoot)avalonia\12.0.2\buildTransitive\Avalonia.targets')" />
   </ImportGroup>
 </Project>

--- a/Chromatics/obj/project.assets.json
+++ b/Chromatics/obj/project.assets.json
@@ -643,7 +643,7 @@
           "lib/net10.0/HueApi.Entertainment.dll": {}
         }
       },
-      "Lumina/7.3.0": {
+      "Lumina/7.4.0": {
         "type": "package",
         "dependencies": {
           "BCnEncoder.Net": "2.2.1",
@@ -1326,10 +1326,10 @@
           "buildTransitive/Sentry.Profiling.targets": {}
         }
       },
-      "Sharlayan/9.0.22-prerelease.33": {
+      "Sharlayan/9.0.24-prerelease.35": {
         "type": "package",
         "dependencies": {
-          "Lumina": "7.3.0",
+          "Lumina": "7.4.0",
           "Lumina.Excel": "7.4.3",
           "NLog": "6.1.2",
           "NLog.Schema": "6.1.2",
@@ -2354,17 +2354,17 @@
         "lib/net9.0/HueApi.Entertainment.dll"
       ]
     },
-    "Lumina/7.3.0": {
-      "sha512": "VGBF/2TjXR4uKYqbTFa3oqHNG7gHvXfhKTSj6PQk2pmL/RZcsmNrFpBO/bhARg0mN3J3slLD95UFPruMkScutw==",
+    "Lumina/7.4.0": {
+      "sha512": "D+q+o5DbSu9EJToqhumk+YKN0PZA0Tj7LqnVGcEdM0Viy7q8cev+IDmpeEv/hXIxML67NoZw9tYaaShIGA9dNA==",
       "type": "package",
-      "path": "lumina/7.3.0",
+      "path": "lumina/7.4.0",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "LICENSE",
         "lib/net10.0/Lumina.dll",
         "lib/net10.0/Lumina.xml",
-        "lumina.7.3.0.nupkg.sha512",
+        "lumina.7.4.0.nupkg.sha512",
         "lumina.nuspec"
       ]
     },
@@ -3235,17 +3235,17 @@
         "sentry.profiling.nuspec"
       ]
     },
-    "Sharlayan/9.0.22-prerelease.33": {
-      "sha512": "LTFy6Fy0YFAvrqodj2IF6cVSoPO9DL2Bz+gmnrRVm/PiSNvljbcIZ4BgGiqS4uT4xZk8uoQrcFv8VI92Joc7Yg==",
+    "Sharlayan/9.0.24-prerelease.35": {
+      "sha512": "3Y7iHOJicYtmYn1jRcx9XxcGG4YHSsY23uzxffSkXRsJ3GHFOkQYHjs4K0Rcq6dg68hn+bDjI7ppWi2eyjfNBA==",
       "type": "package",
-      "path": "sharlayan/9.0.22-prerelease.33",
+      "path": "sharlayan/9.0.24-prerelease.35",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Logo.png",
         "lib/net10.0/Sharlayan.dll",
         "lib/net10.0/Sharlayan.xml",
-        "sharlayan.9.0.22-prerelease.33.nupkg.sha512",
+        "sharlayan.9.0.24-prerelease.35.nupkg.sha512",
         "sharlayan.nuspec"
       ]
     },
@@ -3607,7 +3607,7 @@
       "RGB.NET.Presets >= 3.2.0",
       "Sentry >= 6.4.1",
       "Sentry.Profiling >= 6.4.1",
-      "Sharlayan >= 9.0.22-prerelease.33",
+      "Sharlayan >= 9.0.24-prerelease.35",
       "System.Drawing.Common >= 10.0.7",
       "Velopack >= 0.0.1298"
     ]
@@ -3617,13 +3617,13 @@
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
   },
   "project": {
-    "version": "4.0.154",
+    "version": "4.0.156",
     "restore": {
-      "projectUniqueName": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+      "projectUniqueName": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
       "projectName": "Chromatics",
-      "projectPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+      "projectPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
       "packagesPath": "C:\\Users\\Hanielle\\.nuget\\packages\\",
-      "outputPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
+      "outputPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
       "projectStyle": "PackageReference",
       "fallbackFolders": [
         "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -3643,6 +3643,7 @@
       },
       "frameworks": {
         "net10.0-windows7.0": {
+          "framework": "net10.0-windows7.0",
           "targetAlias": "net10.0-windows7.0",
           "projectReferences": {}
         }
@@ -3661,6 +3662,7 @@
     },
     "frameworks": {
       "net10.0-windows7.0": {
+        "framework": "net10.0-windows7.0",
         "targetAlias": "net10.0-windows7.0",
         "dependencies": {
           "Avalonia": {
@@ -3785,7 +3787,7 @@
           },
           "Sharlayan": {
             "target": "Package",
-            "version": "[9.0.22-prerelease.33, )"
+            "version": "[9.0.24-prerelease.35, )"
           },
           "System.Drawing.Common": {
             "target": "Package",

--- a/Chromatics/obj/project.assets.json
+++ b/Chromatics/obj/project.assets.json
@@ -3560,7 +3560,7 @@
     "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages": {}
   },
   "project": {
-    "version": "4.0.153",
+    "version": "4.0.154",
     "restore": {
       "projectUniqueName": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
       "projectName": "Chromatics",

--- a/Chromatics/obj/project.assets.json
+++ b/Chromatics/obj/project.assets.json
@@ -2,11 +2,11 @@
   "version": 3,
   "targets": {
     "net10.0-windows7.0": {
-      "Avalonia/12.0.1": {
+      "Avalonia/12.0.2": {
         "type": "package",
         "dependencies": {
           "Avalonia.BuildServices": "11.3.2",
-          "Avalonia.Remote.Protocol": "12.0.1",
+          "Avalonia.Remote.Protocol": "12.0.2",
           "MicroCom.Runtime": "0.11.4"
         },
         "compile": {
@@ -107,11 +107,11 @@
           "buildTransitive/Avalonia.BuildServices.targets": {}
         }
       },
-      "Avalonia.Controls.ColorPicker/12.0.1": {
+      "Avalonia.Controls.ColorPicker/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.Remote.Protocol": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.Remote.Protocol": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.Controls.ColorPicker.dll": {
@@ -140,15 +140,15 @@
           }
         }
       },
-      "Avalonia.Desktop/12.0.1": {
+      "Avalonia.Desktop/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.HarfBuzz": "12.0.1",
-          "Avalonia.Native": "12.0.1",
-          "Avalonia.Skia": "12.0.1",
-          "Avalonia.Win32": "12.0.1",
-          "Avalonia.X11": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.HarfBuzz": "12.0.2",
+          "Avalonia.Native": "12.0.2",
+          "Avalonia.Skia": "12.0.2",
+          "Avalonia.Win32": "12.0.2",
+          "Avalonia.X11": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.Desktop.dll": {
@@ -161,10 +161,10 @@
           }
         }
       },
-      "Avalonia.Fonts.Inter/12.0.1": {
+      "Avalonia.Fonts.Inter/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.Fonts.Inter.dll": {
@@ -177,10 +177,10 @@
           }
         }
       },
-      "Avalonia.FreeDesktop/12.0.1": {
+      "Avalonia.FreeDesktop/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "Tmds.DBus.Protocol": "0.92.0"
         },
         "compile": {
@@ -194,10 +194,10 @@
           }
         }
       },
-      "Avalonia.FreeDesktop.AtSpi/12.0.1": {
+      "Avalonia.FreeDesktop.AtSpi/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.FreeDesktop.AtSpi.dll": {
@@ -210,10 +210,10 @@
           }
         }
       },
-      "Avalonia.HarfBuzz/12.0.1": {
+      "Avalonia.HarfBuzz/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3"
@@ -229,10 +229,10 @@
           }
         }
       },
-      "Avalonia.Native/12.0.1": {
+      "Avalonia.Native/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.Native.dll": {
@@ -251,7 +251,7 @@
           }
         }
       },
-      "Avalonia.Remote.Protocol/12.0.1": {
+      "Avalonia.Remote.Protocol/12.0.2": {
         "type": "package",
         "compile": {
           "lib/net10.0/Avalonia.Remote.Protocol.dll": {
@@ -264,16 +264,16 @@
           }
         }
       },
-      "Avalonia.Skia/12.0.1": {
+      "Avalonia.Skia/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "HarfBuzzSharp": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.Linux": "8.3.1.3",
           "HarfBuzzSharp.NativeAssets.WebAssembly": "8.3.1.3",
-          "SkiaSharp": "3.119.3-preview.1.1",
-          "SkiaSharp.NativeAssets.Linux": "3.119.3-preview.1.1",
-          "SkiaSharp.NativeAssets.WebAssembly": "3.119.3-preview.1.1"
+          "SkiaSharp": "3.119.4-preview.1.1",
+          "SkiaSharp.NativeAssets.Linux": "3.119.4-preview.1.1",
+          "SkiaSharp.NativeAssets.WebAssembly": "3.119.4-preview.1.1"
         },
         "compile": {
           "lib/net10.0/Avalonia.Skia.dll": {
@@ -286,10 +286,10 @@
           }
         }
       },
-      "Avalonia.Themes.Fluent/12.0.1": {
+      "Avalonia.Themes.Fluent/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1"
+          "Avalonia": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.Themes.Fluent.dll": {
@@ -302,10 +302,10 @@
           }
         }
       },
-      "Avalonia.Win32/12.0.1": {
+      "Avalonia.Win32/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
+          "Avalonia": "12.0.2",
           "Avalonia.Angle.Windows.Natives": "2.1.25547.20250602"
         },
         "compile": {
@@ -325,13 +325,13 @@
           }
         }
       },
-      "Avalonia.X11/12.0.1": {
+      "Avalonia.X11/12.0.2": {
         "type": "package",
         "dependencies": {
-          "Avalonia": "12.0.1",
-          "Avalonia.FreeDesktop": "12.0.1",
-          "Avalonia.FreeDesktop.AtSpi": "12.0.1",
-          "Avalonia.Skia": "12.0.1"
+          "Avalonia": "12.0.2",
+          "Avalonia.FreeDesktop": "12.0.2",
+          "Avalonia.FreeDesktop.AtSpi": "12.0.2",
+          "Avalonia.Skia": "12.0.2"
         },
         "compile": {
           "lib/net10.0/Avalonia.X11.dll": {
@@ -1346,28 +1346,28 @@
           }
         }
       },
-      "SkiaSharp/3.119.3-preview.1.1": {
+      "SkiaSharp/3.119.4-preview.1.1": {
         "type": "package",
         "dependencies": {
-          "SkiaSharp.NativeAssets.Win32": "3.119.3-preview.1.1",
-          "SkiaSharp.NativeAssets.macOS": "3.119.3-preview.1.1"
+          "SkiaSharp.NativeAssets.Win32": "3.119.4-preview.1.1",
+          "SkiaSharp.NativeAssets.macOS": "3.119.4-preview.1.1"
         },
         "compile": {
-          "ref/net8.0/SkiaSharp.dll": {}
+          "ref/net10.0/SkiaSharp.dll": {}
         },
         "runtime": {
-          "lib/net8.0/SkiaSharp.dll": {
+          "lib/net10.0/SkiaSharp.dll": {
             "related": ".pdb"
           }
         }
       },
-      "SkiaSharp.NativeAssets.Linux/3.119.3-preview.1.1": {
+      "SkiaSharp.NativeAssets.Linux/3.119.4-preview.1.1": {
         "type": "package",
         "compile": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtime": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtimeTargets": {
           "runtimes/linux-arm/native/libSkiaSharp.so": {
@@ -1377,6 +1377,14 @@
           "runtimes/linux-arm64/native/libSkiaSharp.so": {
             "assetType": "native",
             "rid": "linux-arm64"
+          },
+          "runtimes/linux-bionic-arm64/native/libSkiaSharp.so": {
+            "assetType": "native",
+            "rid": "linux-bionic-arm64"
+          },
+          "runtimes/linux-bionic-x64/native/libSkiaSharp.so": {
+            "assetType": "native",
+            "rid": "linux-bionic-x64"
           },
           "runtimes/linux-loongarch64/native/libSkiaSharp.so": {
             "assetType": "native",
@@ -1416,13 +1424,13 @@
           }
         }
       },
-      "SkiaSharp.NativeAssets.macOS/3.119.3-preview.1.1": {
+      "SkiaSharp.NativeAssets.macOS/3.119.4-preview.1.1": {
         "type": "package",
         "compile": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtime": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtimeTargets": {
           "runtimes/osx/native/libSkiaSharp.dylib": {
@@ -1431,26 +1439,26 @@
           }
         }
       },
-      "SkiaSharp.NativeAssets.WebAssembly/3.119.3-preview.1.1": {
+      "SkiaSharp.NativeAssets.WebAssembly/3.119.4-preview.1.1": {
         "type": "package",
         "compile": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtime": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "build": {
           "buildTransitive/netstandard1.0/SkiaSharp.NativeAssets.WebAssembly.props": {},
           "buildTransitive/netstandard1.0/SkiaSharp.NativeAssets.WebAssembly.targets": {}
         }
       },
-      "SkiaSharp.NativeAssets.Win32/3.119.3-preview.1.1": {
+      "SkiaSharp.NativeAssets.Win32/3.119.4-preview.1.1": {
         "type": "package",
         "compile": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtime": {
-          "lib/net8.0/_._": {}
+          "lib/net10.0/_._": {}
         },
         "runtimeTargets": {
           "runtimes/win-arm64/native/libSkiaSharp.dll": {
@@ -1542,10 +1550,10 @@
     }
   },
   "libraries": {
-    "Avalonia/12.0.1": {
-      "sha512": "4OK0u9EdD3ukqA3qTwwTQ7MnRMj+gzBgm/KmpbYRdRTd94OzcioTRnHrc5PJo94SfMEYKq2rfpO3nq9Jddet+w==",
+    "Avalonia/12.0.2": {
+      "sha512": "852xwfNNAUWE+aKWFackMALAKofcpKnM2g4PN8VKfxG1SO8Stlih7d6QFCbjQl46vuR9WBw/ZVGwn4Ovbj/oxQ==",
       "type": "package",
-      "path": "avalonia/12.0.1",
+      "path": "avalonia/12.0.2",
       "hasTools": true,
       "files": [
         ".nupkg.metadata",
@@ -1555,7 +1563,7 @@
         "analyzers/dotnet/cs/Avalonia.Analyzers.CodeFixes.CSharp.dll",
         "analyzers/dotnet/cs/Avalonia.Analyzers.VisualBasic.dll",
         "analyzers/dotnet/cs/Avalonia.Generators.dll",
-        "avalonia.12.0.1.nupkg.sha512",
+        "avalonia.12.0.2.nupkg.sha512",
         "avalonia.nuspec",
         "build/Avalonia.Generators.props",
         "build/Avalonia.props",
@@ -1704,15 +1712,15 @@
         "tools/netstandard2.0/runtimeconfig.json"
       ]
     },
-    "Avalonia.Controls.ColorPicker/12.0.1": {
-      "sha512": "ZQQiTwFZoMFLBlc+vSXENu66OO4wf4c6Rbj2+BM7YKDx4DXCxoWnck51JpvjM/egXqcclttAAIb+/8lVvJXXCw==",
+    "Avalonia.Controls.ColorPicker/12.0.2": {
+      "sha512": "z0NTksfW9B5xNYhFkhMN285SXg62xQ2Vzzmpxsiq5vv036t2aMgHeIE3tomw99sORnOr0EcpAPgycwzIQ7WRIw==",
       "type": "package",
-      "path": "avalonia.controls.colorpicker/12.0.1",
+      "path": "avalonia.controls.colorpicker/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.controls.colorpicker.12.0.1.nupkg.sha512",
+        "avalonia.controls.colorpicker.12.0.2.nupkg.sha512",
         "avalonia.controls.colorpicker.nuspec",
         "lib/net10.0/Avalonia.Controls.ColorPicker.dll",
         "lib/net10.0/Avalonia.Controls.ColorPicker.xml",
@@ -1737,15 +1745,15 @@
         "readme.md"
       ]
     },
-    "Avalonia.Desktop/12.0.1": {
-      "sha512": "jSjO026cA8IqgXszxlcdTkaOM60veMjFgA/D6eqEYLwtLvho/72hdzLeOj/qzgF+ZgEo40gmDKca2Se5VkqlNQ==",
+    "Avalonia.Desktop/12.0.2": {
+      "sha512": "7Hs7AsEoLh4UHNZnwaAZ5d4db2X0BjdLePuev526tm2ZJIOZGLUxKHvY1GcrWIDO9NBw4Iu3WXBUvsFPZ6vXlQ==",
       "type": "package",
-      "path": "avalonia.desktop/12.0.1",
+      "path": "avalonia.desktop/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.desktop.12.0.1.nupkg.sha512",
+        "avalonia.desktop.12.0.2.nupkg.sha512",
         "avalonia.desktop.nuspec",
         "lib/net10.0/Avalonia.Desktop.dll",
         "lib/net10.0/Avalonia.Desktop.xml",
@@ -1753,15 +1761,15 @@
         "lib/net8.0/Avalonia.Desktop.xml"
       ]
     },
-    "Avalonia.Fonts.Inter/12.0.1": {
-      "sha512": "Pm7Xb9fMpjM4i1cpUGtpDtxkMC/oVfijaT93cPl30LPUKPYPbpwm1jkrYwtWLtEr/xTgbUmxyZZvJd0cV9oF8g==",
+    "Avalonia.Fonts.Inter/12.0.2": {
+      "sha512": "2QEaZc52qqO3W58LfGkcV9V3lX4A6uyIt8zJaSb2ULyeyw9CwdLurJ/bwDcYO3M1dwV7LMDcqjOTuqCf8TIZ0Q==",
       "type": "package",
-      "path": "avalonia.fonts.inter/12.0.1",
+      "path": "avalonia.fonts.inter/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.fonts.inter.12.0.1.nupkg.sha512",
+        "avalonia.fonts.inter.12.0.2.nupkg.sha512",
         "avalonia.fonts.inter.nuspec",
         "lib/net10.0/Avalonia.Fonts.Inter.dll",
         "lib/net10.0/Avalonia.Fonts.Inter.xml",
@@ -1769,15 +1777,15 @@
         "lib/net8.0/Avalonia.Fonts.Inter.xml"
       ]
     },
-    "Avalonia.FreeDesktop/12.0.1": {
-      "sha512": "BbYDbu3hEwv2stkLlCh8/+2Y94IjdyxQNj8wQVAiKton2yZEmnwYpBRfQ8v/q7I6BjIJing6dofZk8IG/i82/g==",
+    "Avalonia.FreeDesktop/12.0.2": {
+      "sha512": "KHionmetHeH7g4M653eNPD+GKFHTpX0xd6daBt+Gj03Y9ztEjD4B/P34bCrG81f+KK8evcx3ZygAC79O4M05GQ==",
       "type": "package",
-      "path": "avalonia.freedesktop/12.0.1",
+      "path": "avalonia.freedesktop/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.freedesktop.12.0.1.nupkg.sha512",
+        "avalonia.freedesktop.12.0.2.nupkg.sha512",
         "avalonia.freedesktop.nuspec",
         "lib/net10.0/Avalonia.FreeDesktop.dll",
         "lib/net10.0/Avalonia.FreeDesktop.xml",
@@ -1785,15 +1793,15 @@
         "lib/net8.0/Avalonia.FreeDesktop.xml"
       ]
     },
-    "Avalonia.FreeDesktop.AtSpi/12.0.1": {
-      "sha512": "cswoLoW/QkCQ9X/CRUTscLYS1OgUSAf67N/7BucENwaNX+lQoTPOS4dd8aD+cQjcSPEctc9SH11D4dW1hPx5vw==",
+    "Avalonia.FreeDesktop.AtSpi/12.0.2": {
+      "sha512": "tuo8ry4mFhns6p31RHvCTineppfc8cI0i6J8ifEnmQ5FSHVATTna1tBjyi26ri8qPEX6nmcVgifKTewfpZEMmw==",
       "type": "package",
-      "path": "avalonia.freedesktop.atspi/12.0.1",
+      "path": "avalonia.freedesktop.atspi/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.freedesktop.atspi.12.0.1.nupkg.sha512",
+        "avalonia.freedesktop.atspi.12.0.2.nupkg.sha512",
         "avalonia.freedesktop.atspi.nuspec",
         "lib/net10.0/Avalonia.FreeDesktop.AtSpi.dll",
         "lib/net10.0/Avalonia.FreeDesktop.AtSpi.xml",
@@ -1801,15 +1809,15 @@
         "lib/net8.0/Avalonia.FreeDesktop.AtSpi.xml"
       ]
     },
-    "Avalonia.HarfBuzz/12.0.1": {
-      "sha512": "17A+VIAeIGsYqZSK/ydYzZbbzatBDj2Ls8aF/ZVo6OdeN5W+J9eAQGhS1wPw/GIkGuOkRPBSVwicFXIFCDf/kA==",
+    "Avalonia.HarfBuzz/12.0.2": {
+      "sha512": "HGqFe/HmWHQGvwtji7827/RDtEgQxvm3zdnCFl/P6XAwnqek8MoJpnISRTid76XzTBDtNlVqp7qjOujSIE0QCw==",
       "type": "package",
-      "path": "avalonia.harfbuzz/12.0.1",
+      "path": "avalonia.harfbuzz/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.harfbuzz.12.0.1.nupkg.sha512",
+        "avalonia.harfbuzz.12.0.2.nupkg.sha512",
         "avalonia.harfbuzz.nuspec",
         "lib/net10.0/Avalonia.HarfBuzz.dll",
         "lib/net10.0/Avalonia.HarfBuzz.xml",
@@ -1817,15 +1825,15 @@
         "lib/net8.0/Avalonia.HarfBuzz.xml"
       ]
     },
-    "Avalonia.Native/12.0.1": {
-      "sha512": "RmMRxAMsZDbouQEZtayAR1JBhQ/CSYKpmjyQocAIjUtOWprifueBigr685VCt5TNJRGPPY0OZbDvD8aVpMNUbw==",
+    "Avalonia.Native/12.0.2": {
+      "sha512": "ar8S5eXQY8ttZ3YG5dbtinbC2ltybJU89iwgkpAlLKkV3V7u+4ZXX13o6ilplVyd1lVVSfXgOMvfSMnKQm02Bg==",
       "type": "package",
-      "path": "avalonia.native/12.0.1",
+      "path": "avalonia.native/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.native.12.0.1.nupkg.sha512",
+        "avalonia.native.12.0.2.nupkg.sha512",
         "avalonia.native.nuspec",
         "lib/net10.0/Avalonia.Native.dll",
         "lib/net10.0/Avalonia.Native.xml",
@@ -1834,15 +1842,15 @@
         "runtimes/osx/native/libAvaloniaNative.dylib"
       ]
     },
-    "Avalonia.Remote.Protocol/12.0.1": {
-      "sha512": "8rqhNyde2I/JiW2TjQ8AkUoRclynr0e8yFXKB8VhehA07ejthx4Bnmt3k1DTSlpwTXbM0FRgYAtB1bTlUc6rgg==",
+    "Avalonia.Remote.Protocol/12.0.2": {
+      "sha512": "mlKTvn0cAEQVkRMJunLzDNugZRbtZIksT5yu+XgcAlOvqTHGyZY+mGP+4/+1IwakZx9nrz6SGwI5yrzNT5g0TQ==",
       "type": "package",
-      "path": "avalonia.remote.protocol/12.0.1",
+      "path": "avalonia.remote.protocol/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.remote.protocol.12.0.1.nupkg.sha512",
+        "avalonia.remote.protocol.12.0.2.nupkg.sha512",
         "avalonia.remote.protocol.nuspec",
         "lib/net10.0/Avalonia.Remote.Protocol.dll",
         "lib/net10.0/Avalonia.Remote.Protocol.xml",
@@ -1852,15 +1860,15 @@
         "lib/netstandard2.0/Avalonia.Remote.Protocol.xml"
       ]
     },
-    "Avalonia.Skia/12.0.1": {
-      "sha512": "T850YAUgHpkRX4d3RkfH1ewabA2aLTgdGK+f4hyqeGhZlJYmMs6YjVps266wvr+MggAVUCZ601OLQd9KVfJb6g==",
+    "Avalonia.Skia/12.0.2": {
+      "sha512": "rtnB7M3VymQY4ErpPMot37bNoZ67mTk4tCb1mJjQCnTkCYgTx/o0yDvPPBFgLZAmcmHp00BxT5w12GkXTQjDMQ==",
       "type": "package",
-      "path": "avalonia.skia/12.0.1",
+      "path": "avalonia.skia/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.skia.12.0.1.nupkg.sha512",
+        "avalonia.skia.12.0.2.nupkg.sha512",
         "avalonia.skia.nuspec",
         "lib/net10.0/Avalonia.Skia.dll",
         "lib/net10.0/Avalonia.Skia.xml",
@@ -1868,15 +1876,15 @@
         "lib/net8.0/Avalonia.Skia.xml"
       ]
     },
-    "Avalonia.Themes.Fluent/12.0.1": {
-      "sha512": "/vfTVnz0mZR91cDQn5dHKzngLV0OfCZ0i/uT01uxKu6jqyaPbRwpO68d07N0d6ll6hnvdfySfP4lDY7JWtqr4A==",
+    "Avalonia.Themes.Fluent/12.0.2": {
+      "sha512": "uEDLnrS7flCulIjWHnW6eiPiUqjxxAOh76suASMpQ0pJ+kntTEua5R1VcIulwZff79ArMqTVPejf7u0cxlVI2A==",
       "type": "package",
-      "path": "avalonia.themes.fluent/12.0.1",
+      "path": "avalonia.themes.fluent/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.themes.fluent.12.0.1.nupkg.sha512",
+        "avalonia.themes.fluent.12.0.2.nupkg.sha512",
         "avalonia.themes.fluent.nuspec",
         "lib/net10.0/Avalonia.Themes.Fluent.dll",
         "lib/net10.0/Avalonia.Themes.Fluent.xml",
@@ -1884,15 +1892,15 @@
         "lib/net8.0/Avalonia.Themes.Fluent.xml"
       ]
     },
-    "Avalonia.Win32/12.0.1": {
-      "sha512": "7ETmt7DUlpmGiGRP923B+O8T+I5xjA9yYlUROMAa5Om/IfMutUndj2GOd6RGYw2O9yMgEKJuU0sIumqfB9lAFg==",
+    "Avalonia.Win32/12.0.2": {
+      "sha512": "gVUm4hyUvrFlocL0ycPZGAiN2TQhTv7vTa1I2nRkq/G/h6b5hKNoURjGfnZnXuPK3OnRENGPJjvZ+A9+0d5Jsg==",
       "type": "package",
-      "path": "avalonia.win32/12.0.1",
+      "path": "avalonia.win32/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.win32.12.0.1.nupkg.sha512",
+        "avalonia.win32.12.0.2.nupkg.sha512",
         "avalonia.win32.nuspec",
         "lib/net10.0/Avalonia.Win32.Automation.dll",
         "lib/net10.0/Avalonia.Win32.Automation.xml",
@@ -1904,15 +1912,15 @@
         "lib/net8.0/Avalonia.Win32.xml"
       ]
     },
-    "Avalonia.X11/12.0.1": {
-      "sha512": "8YipKW4Icadwv3og4Fyf2Gj1ISHDjVRy/2qUgWkJTYK9/pXvB0zVsHv96ktWM7CIlpCq1VHkSrrVhnpeQUcXEw==",
+    "Avalonia.X11/12.0.2": {
+      "sha512": "FXFYfqjYYUAWqtgxEQl1cUWsH61GwTUojbRWURfmPAGcYYbm+2djrSOki5ppzAKKcm5lOmjoafYaeti39bSGQA==",
       "type": "package",
-      "path": "avalonia.x11/12.0.1",
+      "path": "avalonia.x11/12.0.2",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
         "Icon.png",
-        "avalonia.x11.12.0.1.nupkg.sha512",
+        "avalonia.x11.12.0.2.nupkg.sha512",
         "avalonia.x11.nuspec",
         "lib/net10.0/Avalonia.X11.dll",
         "lib/net10.0/Avalonia.X11.xml",
@@ -3241,10 +3249,10 @@
         "sharlayan.nuspec"
       ]
     },
-    "SkiaSharp/3.119.3-preview.1.1": {
-      "sha512": "+3ndwD845G4jfuyhtg5rrjryh2mEOr2QfAPFtncvAsRLzGX0ferSJ0223av6Sbw9zsEL6Wk0sk/DrXtEpJoo5A==",
+    "SkiaSharp/3.119.4-preview.1.1": {
+      "sha512": "cyRjWksj/SwFWo7uPfpFk0sOPyUcE+FhF6ENFc3Q100sdJWHEA2nU1PcEeT7LsLFKBvDP/67q0A8vEXc4kvXnA==",
       "type": "package",
-      "path": "skiasharp/3.119.3-preview.1.1",
+      "path": "skiasharp/3.119.4-preview.1.1",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -3252,51 +3260,82 @@
         "README.md",
         "icon.png",
         "interactive-extensions/dotnet/SkiaSharp.DotNet.Interactive.dll",
+        "lib/net10.0-android36.0/SkiaSharp.dll",
+        "lib/net10.0-android36.0/SkiaSharp.pdb",
+        "lib/net10.0-android36.0/SkiaSharp.xml",
+        "lib/net10.0-ios26.2/SkiaSharp.dll",
+        "lib/net10.0-ios26.2/SkiaSharp.pdb",
+        "lib/net10.0-maccatalyst26.2/SkiaSharp.dll",
+        "lib/net10.0-maccatalyst26.2/SkiaSharp.pdb",
+        "lib/net10.0-macos26.2/SkiaSharp.dll",
+        "lib/net10.0-macos26.2/SkiaSharp.pdb",
+        "lib/net10.0-tizen10.0/SkiaSharp.dll",
+        "lib/net10.0-tizen10.0/SkiaSharp.pdb",
+        "lib/net10.0-tvos26.2/SkiaSharp.dll",
+        "lib/net10.0-tvos26.2/SkiaSharp.pdb",
+        "lib/net10.0-windows10.0.19041/SkiaSharp.dll",
+        "lib/net10.0-windows10.0.19041/SkiaSharp.pdb",
+        "lib/net10.0/SkiaSharp.dll",
+        "lib/net10.0/SkiaSharp.pdb",
         "lib/net462/SkiaSharp.dll",
         "lib/net462/SkiaSharp.pdb",
+        "lib/net48/SkiaSharp.dll",
+        "lib/net48/SkiaSharp.pdb",
+        "lib/net6.0-tizen8.0/SkiaSharp.dll",
+        "lib/net6.0-tizen8.0/SkiaSharp.pdb",
         "lib/net6.0/SkiaSharp.dll",
         "lib/net6.0/SkiaSharp.pdb",
-        "lib/net8.0-android34.0/SkiaSharp.dll",
-        "lib/net8.0-android34.0/SkiaSharp.pdb",
-        "lib/net8.0-android34.0/SkiaSharp.xml",
-        "lib/net8.0-ios17.0/SkiaSharp.dll",
-        "lib/net8.0-ios17.0/SkiaSharp.pdb",
-        "lib/net8.0-maccatalyst17.0/SkiaSharp.dll",
-        "lib/net8.0-maccatalyst17.0/SkiaSharp.pdb",
-        "lib/net8.0-macos14.0/SkiaSharp.dll",
-        "lib/net8.0-macos14.0/SkiaSharp.pdb",
-        "lib/net8.0-tizen7.0/SkiaSharp.dll",
-        "lib/net8.0-tizen7.0/SkiaSharp.pdb",
-        "lib/net8.0-tvos17.0/SkiaSharp.dll",
-        "lib/net8.0-tvos17.0/SkiaSharp.pdb",
-        "lib/net8.0-windows10.0.19041/SkiaSharp.dll",
-        "lib/net8.0-windows10.0.19041/SkiaSharp.pdb",
-        "lib/net8.0/SkiaSharp.dll",
-        "lib/net8.0/SkiaSharp.pdb",
+        "lib/net9.0-android35.0/SkiaSharp.dll",
+        "lib/net9.0-android35.0/SkiaSharp.pdb",
+        "lib/net9.0-android35.0/SkiaSharp.xml",
+        "lib/net9.0-ios18.0/SkiaSharp.dll",
+        "lib/net9.0-ios18.0/SkiaSharp.pdb",
+        "lib/net9.0-maccatalyst18.0/SkiaSharp.dll",
+        "lib/net9.0-maccatalyst18.0/SkiaSharp.pdb",
+        "lib/net9.0-macos15.0/SkiaSharp.dll",
+        "lib/net9.0-macos15.0/SkiaSharp.pdb",
+        "lib/net9.0-tizen8.0/SkiaSharp.dll",
+        "lib/net9.0-tizen8.0/SkiaSharp.pdb",
+        "lib/net9.0-tvos18.0/SkiaSharp.dll",
+        "lib/net9.0-tvos18.0/SkiaSharp.pdb",
+        "lib/net9.0-windows10.0.19041/SkiaSharp.dll",
+        "lib/net9.0-windows10.0.19041/SkiaSharp.pdb",
+        "lib/net9.0/SkiaSharp.dll",
+        "lib/net9.0/SkiaSharp.pdb",
         "lib/netstandard2.0/SkiaSharp.dll",
         "lib/netstandard2.0/SkiaSharp.pdb",
         "lib/netstandard2.1/SkiaSharp.dll",
         "lib/netstandard2.1/SkiaSharp.pdb",
+        "ref/net10.0-android36.0/SkiaSharp.dll",
+        "ref/net10.0-ios26.2/SkiaSharp.dll",
+        "ref/net10.0-maccatalyst26.2/SkiaSharp.dll",
+        "ref/net10.0-macos26.2/SkiaSharp.dll",
+        "ref/net10.0-tizen10.0/SkiaSharp.dll",
+        "ref/net10.0-tvos26.2/SkiaSharp.dll",
+        "ref/net10.0-windows10.0.19041/SkiaSharp.dll",
+        "ref/net10.0/SkiaSharp.dll",
         "ref/net462/SkiaSharp.dll",
+        "ref/net48/SkiaSharp.dll",
+        "ref/net6.0-tizen8.0/SkiaSharp.dll",
         "ref/net6.0/SkiaSharp.dll",
-        "ref/net8.0-android34.0/SkiaSharp.dll",
-        "ref/net8.0-ios17.0/SkiaSharp.dll",
-        "ref/net8.0-maccatalyst17.0/SkiaSharp.dll",
-        "ref/net8.0-macos14.0/SkiaSharp.dll",
-        "ref/net8.0-tizen7.0/SkiaSharp.dll",
-        "ref/net8.0-tvos17.0/SkiaSharp.dll",
-        "ref/net8.0-windows10.0.19041/SkiaSharp.dll",
-        "ref/net8.0/SkiaSharp.dll",
+        "ref/net9.0-android35.0/SkiaSharp.dll",
+        "ref/net9.0-ios18.0/SkiaSharp.dll",
+        "ref/net9.0-maccatalyst18.0/SkiaSharp.dll",
+        "ref/net9.0-macos15.0/SkiaSharp.dll",
+        "ref/net9.0-tizen8.0/SkiaSharp.dll",
+        "ref/net9.0-tvos18.0/SkiaSharp.dll",
+        "ref/net9.0-windows10.0.19041/SkiaSharp.dll",
+        "ref/net9.0/SkiaSharp.dll",
         "ref/netstandard2.0/SkiaSharp.dll",
         "ref/netstandard2.1/SkiaSharp.dll",
-        "skiasharp.3.119.3-preview.1.1.nupkg.sha512",
+        "skiasharp.3.119.4-preview.1.1.nupkg.sha512",
         "skiasharp.nuspec"
       ]
     },
-    "SkiaSharp.NativeAssets.Linux/3.119.3-preview.1.1": {
-      "sha512": "ZvpglyfQzhVIUmnPGngliPYcg6ROJNs0BV7XwJ+kktdqY0qe8jifP+UUgaMqTlOTjvuvyCbV7AI4qIBUfRe3Vw==",
+    "SkiaSharp.NativeAssets.Linux/3.119.4-preview.1.1": {
+      "sha512": "rZEnNkds7UWOWCCsi//v3VQ7MWbhqn83J1mCzl9069N1Zza7SXufVvsvpI4qJYUHaRx8ZhAaL0yi3zlKoXaUJw==",
       "type": "package",
-      "path": "skiasharp.nativeassets.linux/3.119.3-preview.1.1",
+      "path": "skiasharp.nativeassets.linux/3.119.4-preview.1.1",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -3304,15 +3343,21 @@
         "README.md",
         "THIRD-PARTY-NOTICES.txt",
         "build/net462/SkiaSharp.NativeAssets.Linux.targets",
+        "build/net48/SkiaSharp.NativeAssets.Linux.targets",
         "buildTransitive/net462/SkiaSharp.NativeAssets.Linux.targets",
+        "buildTransitive/net48/SkiaSharp.NativeAssets.Linux.targets",
         "icon.png",
+        "lib/net10.0/_._",
         "lib/net462/_._",
+        "lib/net48/_._",
         "lib/net6.0/_._",
-        "lib/net8.0/_._",
+        "lib/net9.0/_._",
         "lib/netstandard2.0/_._",
         "lib/netstandard2.1/_._",
         "runtimes/linux-arm/native/libSkiaSharp.so",
         "runtimes/linux-arm64/native/libSkiaSharp.so",
+        "runtimes/linux-bionic-arm64/native/libSkiaSharp.so",
+        "runtimes/linux-bionic-x64/native/libSkiaSharp.so",
         "runtimes/linux-loongarch64/native/libSkiaSharp.so",
         "runtimes/linux-musl-arm/native/libSkiaSharp.so",
         "runtimes/linux-musl-arm64/native/libSkiaSharp.so",
@@ -3322,14 +3367,14 @@
         "runtimes/linux-riscv64/native/libSkiaSharp.so",
         "runtimes/linux-x64/native/libSkiaSharp.so",
         "runtimes/linux-x86/native/libSkiaSharp.so",
-        "skiasharp.nativeassets.linux.3.119.3-preview.1.1.nupkg.sha512",
+        "skiasharp.nativeassets.linux.3.119.4-preview.1.1.nupkg.sha512",
         "skiasharp.nativeassets.linux.nuspec"
       ]
     },
-    "SkiaSharp.NativeAssets.macOS/3.119.3-preview.1.1": {
-      "sha512": "rv8B3OxG5PGQVxudIPV+ppjqUkt98VRzczNV3qNtearHebWXIcelpHEWzCtMSAYBm1rIsTs+KKAQv8/1exr0kQ==",
+    "SkiaSharp.NativeAssets.macOS/3.119.4-preview.1.1": {
+      "sha512": "77gyFnZD0uU12ABgI6pe8Iw2GRBYGryMP4EaHFs7fniffthVT5sf4PTug4ytwNzLKkVDiLobEpIvAJAj3UXwEw==",
       "type": "package",
-      "path": "skiasharp.nativeassets.macos/3.119.3-preview.1.1",
+      "path": "skiasharp.nativeassets.macos/3.119.4-preview.1.1",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -3337,24 +3382,30 @@
         "README.md",
         "THIRD-PARTY-NOTICES.txt",
         "build/net462/SkiaSharp.NativeAssets.macOS.targets",
+        "build/net48/SkiaSharp.NativeAssets.macOS.targets",
+        "buildTransitive/net10.0-macos26.2/SkiaSharp.NativeAssets.macOS.targets",
         "buildTransitive/net462/SkiaSharp.NativeAssets.macOS.targets",
-        "buildTransitive/net8.0-macos14.0/SkiaSharp.NativeAssets.macOS.targets",
+        "buildTransitive/net48/SkiaSharp.NativeAssets.macOS.targets",
+        "buildTransitive/net9.0-macos15.0/SkiaSharp.NativeAssets.macOS.targets",
         "icon.png",
+        "lib/net10.0-macos26.2/_._",
+        "lib/net10.0/_._",
         "lib/net462/_._",
+        "lib/net48/_._",
         "lib/net6.0/_._",
-        "lib/net8.0-macos14.0/_._",
-        "lib/net8.0/_._",
+        "lib/net9.0-macos15.0/_._",
+        "lib/net9.0/_._",
         "lib/netstandard2.0/_._",
         "lib/netstandard2.1/_._",
         "runtimes/osx/native/libSkiaSharp.dylib",
-        "skiasharp.nativeassets.macos.3.119.3-preview.1.1.nupkg.sha512",
+        "skiasharp.nativeassets.macos.3.119.4-preview.1.1.nupkg.sha512",
         "skiasharp.nativeassets.macos.nuspec"
       ]
     },
-    "SkiaSharp.NativeAssets.WebAssembly/3.119.3-preview.1.1": {
-      "sha512": "Gzvr/fcJZODWNoLVBAIiM8NKudvZ9yL6WHb87fk7iadio9BWQR7GS0fUvWvE3kYaRAAutsjPdGAnkDR0ujlVDw==",
+    "SkiaSharp.NativeAssets.WebAssembly/3.119.4-preview.1.1": {
+      "sha512": "IyNI0QRJGl5sT0Dz2rGHBYVmenNoXcOCaC21avrLG5LwkX8ou0PluW2Hgz7NxHxiRL9D0kPmtoYWrr3uxd1NgA==",
       "type": "package",
-      "path": "skiasharp.nativeassets.webassembly/3.119.3-preview.1.1",
+      "path": "skiasharp.nativeassets.webassembly/3.119.4-preview.1.1",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -3379,19 +3430,21 @@
         "buildTransitive/netstandard1.0/libSkiaSharp.a/3.1.56/st/libSkiaSharp.a",
         "buildTransitive/netstandard1.0/libSkiaSharp.a/3.1.7/libSkiaSharp.a",
         "icon.png",
+        "lib/net10.0/_._",
         "lib/net462/_._",
+        "lib/net48/_._",
         "lib/net6.0/_._",
-        "lib/net8.0/_._",
+        "lib/net9.0/_._",
         "lib/netstandard2.0/_._",
         "lib/netstandard2.1/_._",
-        "skiasharp.nativeassets.webassembly.3.119.3-preview.1.1.nupkg.sha512",
+        "skiasharp.nativeassets.webassembly.3.119.4-preview.1.1.nupkg.sha512",
         "skiasharp.nativeassets.webassembly.nuspec"
       ]
     },
-    "SkiaSharp.NativeAssets.Win32/3.119.3-preview.1.1": {
-      "sha512": "PkMb1pGPBSW3ZL0IVKP9DZs+w065HVs4jGQELsbkmKzKSL5P8KHLkrrmnv2XpFpXtx2njOllB8243N1dBMK+CQ==",
+    "SkiaSharp.NativeAssets.Win32/3.119.4-preview.1.1": {
+      "sha512": "BYwNLG02IAYMsBPgU9lM37xJgCM3B/2X5z1FQEBR34dmn+Hxvcw8X83PInY2rzix7mlbcv7OF8UHjf7yMbsDaA==",
       "type": "package",
-      "path": "skiasharp.nativeassets.win32/3.119.3-preview.1.1",
+      "path": "skiasharp.nativeassets.win32/3.119.4-preview.1.1",
       "files": [
         ".nupkg.metadata",
         ".signature.p7s",
@@ -3399,13 +3452,17 @@
         "README.md",
         "THIRD-PARTY-NOTICES.txt",
         "build/net462/SkiaSharp.NativeAssets.Win32.targets",
+        "build/net48/SkiaSharp.NativeAssets.Win32.targets",
         "buildTransitive/net462/SkiaSharp.NativeAssets.Win32.targets",
+        "buildTransitive/net48/SkiaSharp.NativeAssets.Win32.targets",
         "icon.png",
+        "lib/net10.0-windows10.0.19041/_._",
+        "lib/net10.0/_._",
         "lib/net462/_._",
-        "lib/net6.0-windows10.0.19041/_._",
+        "lib/net48/_._",
         "lib/net6.0/_._",
-        "lib/net8.0-windows10.0.19041/_._",
-        "lib/net8.0/_._",
+        "lib/net9.0-windows10.0.19041/_._",
+        "lib/net9.0/_._",
         "lib/netstandard2.0/_._",
         "lib/netstandard2.1/_._",
         "runtimes/win-arm64/native/libSkiaSharp.dll",
@@ -3414,7 +3471,7 @@
         "runtimes/win-x64/native/libSkiaSharp.pdb",
         "runtimes/win-x86/native/libSkiaSharp.dll",
         "runtimes/win-x86/native/libSkiaSharp.pdb",
-        "skiasharp.nativeassets.win32.3.119.3-preview.1.1.nupkg.sha512",
+        "skiasharp.nativeassets.win32.3.119.4-preview.1.1.nupkg.sha512",
         "skiasharp.nativeassets.win32.nuspec"
       ]
     },
@@ -3520,12 +3577,12 @@
   },
   "projectFileDependencyGroups": {
     "net10.0-windows7.0": [
-      "Avalonia >= 12.0.1",
-      "Avalonia.Controls.ColorPicker >= 12.0.1",
+      "Avalonia >= 12.0.2",
+      "Avalonia.Controls.ColorPicker >= 12.0.2",
       "Avalonia.Controls.DataGrid >= 12.0.0",
-      "Avalonia.Desktop >= 12.0.1",
-      "Avalonia.Fonts.Inter >= 12.0.1",
-      "Avalonia.Themes.Fluent >= 12.0.1",
+      "Avalonia.Desktop >= 12.0.2",
+      "Avalonia.Fonts.Inter >= 12.0.2",
+      "Avalonia.Themes.Fluent >= 12.0.2",
       "CommunityToolkit.Mvvm >= 8.4.2",
       "HidSharp >= 2.6.4",
       "HueApi >= 3.2.0",
@@ -3562,11 +3619,11 @@
   "project": {
     "version": "4.0.154",
     "restore": {
-      "projectUniqueName": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+      "projectUniqueName": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
       "projectName": "Chromatics",
-      "projectPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
+      "projectPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\Chromatics.csproj",
       "packagesPath": "C:\\Users\\Hanielle\\.nuget\\packages\\",
-      "outputPath": "D:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
+      "outputPath": "d:\\Git Projects\\roxaskeyheart\\Chromatics Workbench\\Chromatics\\Chromatics\\obj\\",
       "projectStyle": "PackageReference",
       "fallbackFolders": [
         "C:\\Program Files (x86)\\Microsoft Visual Studio\\Shared\\NuGetPackages"
@@ -3586,7 +3643,6 @@
       },
       "frameworks": {
         "net10.0-windows7.0": {
-          "framework": "net10.0-windows7.0",
           "targetAlias": "net10.0-windows7.0",
           "projectReferences": {}
         }
@@ -3605,16 +3661,15 @@
     },
     "frameworks": {
       "net10.0-windows7.0": {
-        "framework": "net10.0-windows7.0",
         "targetAlias": "net10.0-windows7.0",
         "dependencies": {
           "Avalonia": {
             "target": "Package",
-            "version": "[12.0.1, )"
+            "version": "[12.0.2, )"
           },
           "Avalonia.Controls.ColorPicker": {
             "target": "Package",
-            "version": "[12.0.1, )"
+            "version": "[12.0.2, )"
           },
           "Avalonia.Controls.DataGrid": {
             "target": "Package",
@@ -3622,15 +3677,15 @@
           },
           "Avalonia.Desktop": {
             "target": "Package",
-            "version": "[12.0.1, )"
+            "version": "[12.0.2, )"
           },
           "Avalonia.Fonts.Inter": {
             "target": "Package",
-            "version": "[12.0.1, )"
+            "version": "[12.0.2, )"
           },
           "Avalonia.Themes.Fluent": {
             "target": "Package",
-            "version": "[12.0.1, )"
+            "version": "[12.0.2, )"
           },
           "CommunityToolkit.Mvvm": {
             "target": "Package",
@@ -3757,7 +3812,7 @@
             "privateAssets": "all"
           }
         },
-        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\10.0.202/PortableRuntimeIdentifierGraph.json",
+        "runtimeIdentifierGraphPath": "C:\\Program Files\\dotnet\\sdk\\10.0.203/PortableRuntimeIdentifierGraph.json",
         "packagesToPrune": {
           "Microsoft.CSharp": "(,4.7.32767]",
           "Microsoft.VisualBasic": "(,10.4.32767]",

--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ If you wish to build Chromatics yourself, you can download the active branch and
 ### Open Source Libraries ### 
 * [RGB.NET](https://github.com/DarthAffe/RGB.NET) - used for RGB device integration
 * [Sharlayan](https://github.com/FFXIVAPP/sharlayan) - used for FFXIV memory reading
-* [Artemis](https://github.com/Artemis-RGB/Artemis) - borrowed some code base and RGB.NET profiles, not actually a dependency
-* [FFXIVWeather](https://github.com/karashiiro/FFXIVWeather) - For calculating current weather.
 * [Sentry](https://sentry.io/) - error monitoring, logs, metrics, tracing, and profiling
 <br><br>
 


### PR DESCRIPTION
## Summary

Pre-release rollup of v4.0.154 → v4.0.156:

- **v4.0.154 — Sentry triage / fewer false-positive crashes.** `UnobservedTaskException` no longer force-crashes for benign socket aborts (Hue/OpenRGB shutdown, network resets, OperationCanceled, ObjectDisposed); Sentry's `BeforeSend` drops the same set so they don't ship as Issues. Layer save retries `File.Replace` with backoff (50/100/200/400/800 ms) on transient `IOException` / `UnauthorizedAccessException` (AV, OneDrive, Dropbox). RGB.NET surface/device init errors no longer auto-forward to Sentry — iCUE/OpenRGB unavailable is a user-environment condition, not a bug. `Logger.WriteConsole` gains an opt-out `forwardToSentry` parameter.
- **v4.0.155 — Dependabot rollup.** Avalonia + Avalonia.Desktop + Avalonia.Themes.Fluent + Avalonia.Fonts.Inter + Avalonia.Controls.ColorPicker 12.0.1 → 12.0.2 (PR #181). Microsoft.NET.Test.Sdk 17.14.1 → 18.5.1 (PR #182). coverlet.collector 6.0.4 → 10.0.0 (PR #179). Also drops the now-redundant loose Sharlayan `<Reference>` + copy block from `Chromatics.DecoratorHarnessUI.csproj` — the harness picks up Sharlayan transitively via its `ProjectReference` to Chromatics, and the loose-DLL folder is no longer in git.
- **v4.0.156 — Sharlayan bump.** 9.0.22-prerelease.33 → 9.0.24-prerelease.35 in both `Chromatics.csproj` and `Chromatics.Tests.csproj`.
- CHANGELOG condensed under 4.0.156 for the user-facing release notes.

## Test plan

- [x] `./test.cmd` passes — 130/130 xUnit
- [x] `Chromatics.DecoratorHarnessUI` builds clean in Release
- [ ] Smoke test on a machine without iCUE / OpenRGB running — confirm no Sentry events surface for "Device Error: …"
- [ ] Smoke test the Hue/OpenRGB shutdown path — confirm no crash dialog from a transient socket abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)
