### PR TITLE
4.3.25: idle refresh-rate setting and copying layers from unavailable devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 All notable changes to Chromatics are documented here.
 
-## 4.3.25
+## 4.3.26
 
-- Layers saved for a disabled or disconnected device can now be copied to another device. The copy dialog lists these devices with a label showing their state, and a checkbox hides them if you prefer a shorter list.
-- New setting under Settings → General: lower the RGB refresh rate while FFXIV is not running. Enabled by default; turn it off to keep your configured refresh rate at all times.
+- Layers saved for a disabled or disconnected devices can now be copied to another device.
+- New setting under Settings → General: lower the RGB refresh rate while FFXIV is not running.
 
 ## 4.3.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Chromatics are documented here.
 
+## 4.3.25
+
+- Layers saved for a disabled or disconnected device can now be copied to another device. The copy dialog lists these devices with a label showing their state, and a checkbox hides them if you prefer a shorter list.
+- New setting under Settings → General: lower the RGB refresh rate while FFXIV is not running. Enabled by default; turn it off to keep your configured refresh rate at all times.
+
 ## 4.3.24
 
 - **New:** Nanoleaf smart-light support (Beta). Covers the panel family (Shapes, Canvas, Elements, Lines, Aurora) and other controllers that speak the Nanoleaf OpenAPI. Enable it from Settings → Device Providers and pair each controller with a one-time button press; effects render across the panels at their real physical positions. Layer assignments stay with their panels if you add or remove panels from the wall later. Essentials bulbs and strips are not supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 All notable changes to Chromatics are documented here.
 
-## 4.3.26
+## 4.3.27
 
-- Layers saved for a disabled or disconnected devices can now be copied to another device.
+- Layers saved for a disabled or disconnected device can now be copied to another device.
 - New setting under Settings → General: lower the RGB refresh rate while FFXIV is not running.
+- Fixed the update prompt showing the newest version's heading twice in its changelog.
 
 ## 4.3.24
 

--- a/Chromatics.Tests/Helpers/LayerCopierTests.cs
+++ b/Chromatics.Tests/Helpers/LayerCopierTests.cs
@@ -1,0 +1,80 @@
+using Chromatics.Helpers;
+using RGB.NET.Core;
+
+namespace Chromatics.Tests.Helpers;
+
+// Pins the default LedId mapping used when copying layers from a device
+// that is disabled or no longer connected: the layer's own LedId set
+// stands in for the missing device, so these rules decide where each key
+// lands on the destination before the user touches the override dropdowns.
+public class LayerCopierTests
+{
+    [Fact]
+    public void KeyboardPair_MapsIdentity_OnlyWhereDestinationHasTheKey()
+    {
+        var used = new[] { LedId.Keyboard_A, LedId.Keyboard_B, LedId.Keyboard_NumLock };
+        var destIds = new List<LedId> { LedId.Keyboard_A, LedId.Keyboard_B }; // no numpad
+
+        var map = LayerCopier.ComputeDefaultMappingForLayer(
+            used, RGBDeviceType.Keyboard, RGBDeviceType.Keyboard, destIds);
+
+        Assert.Equal(LedId.Keyboard_A, map[LedId.Keyboard_A]);
+        Assert.Equal(LedId.Keyboard_B, map[LedId.Keyboard_B]);
+        // Keyboard pairs never fall back positionally: a missing key is
+        // dropped so it can't land on an unrelated physical key.
+        Assert.False(map.ContainsKey(LedId.Keyboard_NumLock));
+    }
+
+    [Fact]
+    public void NonKeyboard_ExactIdMatchWins()
+    {
+        var used = new[] { LedId.Custom1, LedId.Custom2 };
+        var destIds = new List<LedId> { LedId.Custom1, LedId.Custom2, LedId.Custom3 };
+
+        var map = LayerCopier.ComputeDefaultMappingForLayer(
+            used, RGBDeviceType.LedStripe, RGBDeviceType.LedStripe, destIds);
+
+        Assert.Equal(LedId.Custom1, map[LedId.Custom1]);
+        Assert.Equal(LedId.Custom2, map[LedId.Custom2]);
+    }
+
+    [Fact]
+    public void NonKeyboard_OrdinalFallback_WhenIdsDoNotOverlap()
+    {
+        // Source painted Custom5..Custom7; destination only has Custom1..Custom3.
+        var used = new[] { LedId.Custom5, LedId.Custom6, LedId.Custom7 };
+        var destIds = new List<LedId> { LedId.Custom1, LedId.Custom2, LedId.Custom3 };
+
+        var map = LayerCopier.ComputeDefaultMappingForLayer(
+            used, RGBDeviceType.LedStripe, RGBDeviceType.Mouse, destIds);
+
+        Assert.Equal(LedId.Custom1, map[LedId.Custom5]);
+        Assert.Equal(LedId.Custom2, map[LedId.Custom6]);
+        Assert.Equal(LedId.Custom3, map[LedId.Custom7]);
+    }
+
+    [Fact]
+    public void NonKeyboard_SourceLargerThanDestination_DropsTheTail()
+    {
+        var used = new[] { LedId.Custom5, LedId.Custom6, LedId.Custom7 };
+        var destIds = new List<LedId> { LedId.Custom1 };
+
+        var map = LayerCopier.ComputeDefaultMappingForLayer(
+            used, RGBDeviceType.LedStripe, RGBDeviceType.LedStripe, destIds);
+
+        Assert.Equal(LedId.Custom1, map[LedId.Custom5]);
+        Assert.False(map.ContainsKey(LedId.Custom6));
+        Assert.False(map.ContainsKey(LedId.Custom7));
+    }
+
+    [Fact]
+    public void EmptyOrMissingInputs_ReturnEmptyMap()
+    {
+        Assert.Empty(LayerCopier.ComputeDefaultMappingForLayer(
+            Array.Empty<LedId>(), RGBDeviceType.Keyboard, RGBDeviceType.Keyboard, new List<LedId> { LedId.Keyboard_A }));
+        Assert.Empty(LayerCopier.ComputeDefaultMappingForLayer(
+            null, RGBDeviceType.Keyboard, RGBDeviceType.Keyboard, new List<LedId>()));
+        Assert.Empty(LayerCopier.ComputeDefaultMappingForLayer(
+            new[] { LedId.Keyboard_A }, RGBDeviceType.Keyboard, RGBDeviceType.Keyboard, null));
+    }
+}

--- a/Chromatics.Tests/Helpers/UpdateNotesTests.cs
+++ b/Chromatics.Tests/Helpers/UpdateNotesTests.cs
@@ -1,0 +1,62 @@
+using Chromatics.Helpers;
+
+namespace Chromatics.Tests.Helpers;
+
+// Pins the release-notes trimming behind the update dialog. Notes embedded
+// by older publishes start with their own version heading and carry every
+// older changelog section; the dialog adds its own heading per release, so
+// rendering them raw doubled the version line and repeated old sections.
+public class UpdateNotesTests
+{
+    [Fact]
+    public void OldFormatNotes_ReduceToOwnBullets()
+    {
+        var notes = "## 4.3.26\n\n- New feature one.\n- Fix two.\n\n## 4.3.24\n\n- Old bullet.\n";
+
+        var trimmed = UpdateService.TrimNotesToOwnSection(notes, "4.3.26");
+
+        Assert.Equal("- New feature one.\n- Fix two.", trimmed.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void NewFormatNotes_BulletsOnly_PassThroughUnchanged()
+    {
+        var notes = "- New feature one.\n- Fix two.";
+
+        var trimmed = UpdateService.TrimNotesToOwnSection(notes, "4.3.26");
+
+        Assert.Equal(notes, trimmed.Replace("\r\n", "\n"));
+    }
+
+    [Theory]
+    [InlineData("## 4.3.26.0\n\n- Bullet.")]
+    [InlineData("## [4.3.26]\n\n- Bullet.")]
+    [InlineData("## v4.3.26\n\n- Bullet.")]
+    [InlineData("## 4.3.26 - 2026-07-07\n\n- Bullet.")]
+    public void HeadingVariants_AreAllStripped(string notes)
+    {
+        var trimmed = UpdateService.TrimNotesToOwnSection(notes, "4.3.26");
+
+        Assert.Equal("- Bullet.", trimmed);
+    }
+
+    [Fact]
+    public void DifferentVersionHeading_IsNotStripped_ButLaterSectionsAreCut()
+    {
+        // A mislabelled asset should not lose its first line; only the
+        // trailing sections get cut.
+        var notes = "- Bullet without heading.\n\n## 4.3.20\n\n- Old.";
+
+        var trimmed = UpdateService.TrimNotesToOwnSection(notes, "4.3.26");
+
+        Assert.Equal("- Bullet without heading.", trimmed.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public void EmptyOrWhitespaceNotes_ReturnEmpty()
+    {
+        Assert.Equal(string.Empty, UpdateService.TrimNotesToOwnSection("", "4.3.26"));
+        Assert.Equal(string.Empty, UpdateService.TrimNotesToOwnSection("   ", "4.3.26"));
+        Assert.Equal(string.Empty, UpdateService.TrimNotesToOwnSection(null, "4.3.26"));
+    }
+}

--- a/Chromatics/Chromatics.csproj
+++ b/Chromatics/Chromatics.csproj
@@ -10,7 +10,7 @@
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <StartupObject>Chromatics.Program</StartupObject>
-    <Version>4.3.25.0</Version>
+    <Version>4.3.26.0</Version>
     <Authors>Danielle Thompson</Authors>
     <!-- ApplicationManifest is conditional: local Debug + Release builds embed
          app.manifest (no fusion-identity <msix> element) so VS debug runs and

--- a/Chromatics/Chromatics.csproj
+++ b/Chromatics/Chromatics.csproj
@@ -10,7 +10,7 @@
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <StartupObject>Chromatics.Program</StartupObject>
-    <Version>4.3.24.0</Version>
+    <Version>4.3.25.0</Version>
     <Authors>Danielle Thompson</Authors>
     <!-- ApplicationManifest is conditional: local Debug + Release builds embed
          app.manifest (no fusion-identity <msix> element) so VS debug runs and

--- a/Chromatics/Chromatics.csproj
+++ b/Chromatics/Chromatics.csproj
@@ -10,7 +10,7 @@
     <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <StartupObject>Chromatics.Program</StartupObject>
-    <Version>4.3.26.0</Version>
+    <Version>4.3.27.0</Version>
     <Authors>Danielle Thompson</Authors>
     <!-- ApplicationManifest is conditional: local Debug + Release builds embed
          app.manifest (no fusion-identity <msix> element) so VS debug runs and

--- a/Chromatics/Core/RGBController.cs
+++ b/Chromatics/Core/RGBController.cs
@@ -115,13 +115,24 @@ namespace Chromatics.Core
 
         private const double IdleUpdateFrequency = 0.05; // 20 Hz
 
+        // Tracks the last requested state so the Settings toggle can
+        // re-apply the rate without knowing whether the game is attached.
+        private static bool _idleRateRequested;
+
         private static void SetIdleUpdateRate(bool idle)
         {
+            _idleRateRequested = idle;
             if (_timerUpdateTrigger == null) return;
-            _timerUpdateTrigger.UpdateFrequency = idle
+
+            var settings = AppSettings.GetSettings();
+            _timerUpdateTrigger.UpdateFrequency = idle && settings.idleRefreshWhenDisconnected
                 ? IdleUpdateFrequency
-                : AppSettings.GetSettings().rgbRefreshRate;
+                : settings.rgbRefreshRate;
         }
+
+        // Called when the user flips the idle-refresh setting so the change
+        // lands immediately instead of on the next connect or disconnect.
+        public static void ReapplyIdleUpdateRate() => SetIdleUpdateRate(_idleRateRequested);
 
         // Runs one provider's load block and turns assembly-load faults into
         // console guidance instead of a startup crash. Windows App Control

--- a/Chromatics/Helpers/LayerCopier.cs
+++ b/Chromatics/Helpers/LayerCopier.cs
@@ -84,6 +84,52 @@ namespace Chromatics.Helpers
             return map;
         }
 
+        // Overload for a source device that is disabled or no longer
+        // connected: its layers survive in layers.chromatics4 but there is
+        // no IRGBDevice to enumerate. The layer's own LedId set stands in
+        // for the device - identity match where the destination has the
+        // same LedId, ordinal fallback otherwise (Nth used source LedId ->
+        // Nth destination LED). The user can correct any row from the
+        // per-layer mapping expander as usual.
+        public static Dictionary<LedId, LedId> ComputeDefaultMappingForLayer(
+            IReadOnlyCollection<LedId> usedSourceLedIds,
+            RGBDeviceType sourceType,
+            IRGBDevice dest)
+        {
+            var map = new Dictionary<LedId, LedId>();
+            if (usedSourceLedIds == null || dest == null) return map;
+            if (usedSourceLedIds.Count == 0) return map;
+
+            var destLeds = dest.OrderBy(l => (int)l.Id).ToList();
+            var destIds = new HashSet<LedId>(destLeds.Select(l => l.Id));
+
+            bool keyboardPair = sourceType == RGBDeviceType.Keyboard
+                             && dest.DeviceInfo.DeviceType == RGBDeviceType.Keyboard;
+
+            if (keyboardPair)
+            {
+                foreach (var ledId in usedSourceLedIds)
+                    if (destIds.Contains(ledId))
+                        map[ledId] = ledId;
+                return map;
+            }
+
+            var orderedSource = usedSourceLedIds.OrderBy(id => (int)id).ToList();
+            int n = Math.Min(orderedSource.Count, destLeds.Count);
+            var positionalFallback = new Dictionary<LedId, LedId>();
+            for (int i = 0; i < n; i++)
+                positionalFallback[orderedSource[i]] = destLeds[i].Id;
+
+            foreach (var ledId in usedSourceLedIds)
+            {
+                if (destIds.Contains(ledId))
+                    map[ledId] = ledId;
+                else if (positionalFallback.TryGetValue(ledId, out var fallback))
+                    map[ledId] = fallback;
+            }
+            return map;
+        }
+
         // One copy operation. The view-model passes a list of these
         // into Apply; each represents "copy this source layer onto
         // the destination with this LedId mapping".

--- a/Chromatics/Helpers/LayerCopier.cs
+++ b/Chromatics/Helpers/LayerCopier.cs
@@ -96,15 +96,32 @@ namespace Chromatics.Helpers
             RGBDeviceType sourceType,
             IRGBDevice dest)
         {
+            if (usedSourceLedIds == null || dest == null) return new Dictionary<LedId, LedId>();
+
+            return ComputeDefaultMappingForLayer(
+                usedSourceLedIds,
+                sourceType,
+                dest.DeviceInfo.DeviceType,
+                dest.OrderBy(l => (int)l.Id).Select(l => l.Id).ToList());
+        }
+
+        // Device-free core so the mapping rules stay unit-testable -
+        // IRGBDevice takes a full device stack to construct, which keeps
+        // the rules out of reach of plain xUnit otherwise.
+        public static Dictionary<LedId, LedId> ComputeDefaultMappingForLayer(
+            IReadOnlyCollection<LedId> usedSourceLedIds,
+            RGBDeviceType sourceType,
+            RGBDeviceType destType,
+            IReadOnlyList<LedId> destLedIdsOrdered)
+        {
             var map = new Dictionary<LedId, LedId>();
-            if (usedSourceLedIds == null || dest == null) return map;
+            if (usedSourceLedIds == null || destLedIdsOrdered == null) return map;
             if (usedSourceLedIds.Count == 0) return map;
 
-            var destLeds = dest.OrderBy(l => (int)l.Id).ToList();
-            var destIds = new HashSet<LedId>(destLeds.Select(l => l.Id));
+            var destIds = new HashSet<LedId>(destLedIdsOrdered);
 
             bool keyboardPair = sourceType == RGBDeviceType.Keyboard
-                             && dest.DeviceInfo.DeviceType == RGBDeviceType.Keyboard;
+                             && destType == RGBDeviceType.Keyboard;
 
             if (keyboardPair)
             {
@@ -115,10 +132,10 @@ namespace Chromatics.Helpers
             }
 
             var orderedSource = usedSourceLedIds.OrderBy(id => (int)id).ToList();
-            int n = Math.Min(orderedSource.Count, destLeds.Count);
+            int n = Math.Min(orderedSource.Count, destLedIdsOrdered.Count);
             var positionalFallback = new Dictionary<LedId, LedId>();
             for (int i = 0; i < n; i++)
-                positionalFallback[orderedSource[i]] = destLeds[i].Id;
+                positionalFallback[orderedSource[i]] = destLedIdsOrdered[i];
 
             foreach (var ledId in usedSourceLedIds)
             {

--- a/Chromatics/Helpers/UpdateService.cs
+++ b/Chromatics/Helpers/UpdateService.cs
@@ -21,6 +21,32 @@ namespace Chromatics.Helpers
         private const string StableFeedUrl = "https://chromaticsffxiv.com/chromatics4/update/stable/";
         private const string BetaFeedUrl   = "https://chromaticsffxiv.com/chromatics4/update/beta/";
 
+        // The update dialog prepends its own "## {version}" heading per
+        // release, but notes embedded by older publishes start with the
+        // version's changelog heading themselves and run to the end of
+        // CHANGELOG.md - rendering both doubled the version line and
+        // stacked older sections into every entry. Trim each release's
+        // notes to just its own bullets: drop a leading heading that names
+        // this version (any of the changelog heading shapes, 4-part
+        // tolerated), then cut at the next "## " section. New publishes
+        // embed bullets only, so this is a no-op for them.
+        public static string TrimNotesToOwnSection(string notes, string version)
+        {
+            if (string.IsNullOrWhiteSpace(notes)) return string.Empty;
+            var text = notes.Trim();
+
+            var ownHeading = new System.Text.RegularExpressions.Regex(
+                @"^##\s+\[?v?" + System.Text.RegularExpressions.Regex.Escape(version) + @"(\.0)?\]?[^\n]*\r?\n?");
+            text = ownHeading.Replace(text, string.Empty, 1).TrimStart();
+
+            var nextSection = System.Text.RegularExpressions.Regex.Match(
+                text, @"^##\s+\S", System.Text.RegularExpressions.RegexOptions.Multiline);
+            if (nextSection.Success)
+                text = text[..nextSection.Index].TrimEnd();
+
+            return text;
+        }
+
         // Marker file that ships inside the nupkg for real beta builds only.
         // Stable releases (including any a beta install migrates to) never have it,
         // so after a beta→stable migration the title drops the [BETA] suffix cleanly.

--- a/Chromatics/Models/SettingsModel.cs
+++ b/Chromatics/Models/SettingsModel.cs
@@ -29,6 +29,10 @@ namespace Chromatics.Models
         public bool showEmulatorDevices { get; set; } = false;
         public KeyboardLocalization keyboardLayout { get; set; } = KeyboardLocalization.qwerty;
         public double rgbRefreshRate { get; set; } = 0.05;
+        // Drop the surface tick rate to the idle rate while FFXIV is not
+        // connected; the configured rate resumes on attach. Off means the
+        // configured rate runs at all times.
+        public bool idleRefreshWhenDisconnected { get; set; } = true;
         public int globalbrightness { get; set; } = 100;
         public double criticalHpPercentage { get; set; } = 20.0;
         public int screenCaptureTopLeftOffsetX { get; set; } = 0;

--- a/Chromatics/ViewModels/CopyLayersDialogViewModel.cs
+++ b/Chromatics/ViewModels/CopyLayersDialogViewModel.cs
@@ -85,7 +85,26 @@ namespace Chromatics.ViewModels
                           ?? Devices.FirstOrDefault();
         }
 
-        partial void OnHideUnavailableChanged(bool value) => RebuildDeviceList();
+        partial void OnHideUnavailableChanged(bool value)
+        {
+            var before = SelectedSource;
+            RebuildDeviceList();
+
+            // A surviving selection means OnSelectedSourceChanged never
+            // fired, which would leave the destination list stale against
+            // the new filter - disabled devices lingering after hiding
+            // them, or missing after showing them again.
+            if (ReferenceEquals(before, SelectedSource))
+            {
+                RebuildDestinationOptions();
+                if (SelectedDestination == null
+                    || !AvailableDestinations.Any(d => d.DeviceId == SelectedDestination.DeviceId))
+                {
+                    SelectedDestination = AvailableDestinations.FirstOrDefault();
+                }
+                RebuildLayerRows();
+            }
+        }
 
         public ObservableCollection<DeviceItem> Devices { get; } = new();
         public ObservableCollection<DeviceItem> AvailableDestinations { get; } = new();

--- a/Chromatics/ViewModels/CopyLayersDialogViewModel.cs
+++ b/Chromatics/ViewModels/CopyLayersDialogViewModel.cs
@@ -31,22 +31,61 @@ namespace Chromatics.ViewModels
 
             foreach (var (guid, device) in _connectedDevices)
             {
-                Devices.Add(new DeviceItem
+                _allDevices.Add(new DeviceItem
                 {
                     DeviceId = guid,
                     Name = device.DeviceInfo?.DeviceName ?? "Device",
                     DeviceType = device.DeviceInfo?.DeviceType ?? RGBDeviceType.Unknown,
+                    IsPresent = true,
+                    IsDisabled = MappingLayers.IsDeviceDisabled(guid),
                 });
             }
 
-            SelectedSource = Devices.FirstOrDefault(d => d.DeviceId == initialSourceGuid)
-                          ?? Devices.FirstOrDefault();
-            RebuildDestinationOptions();
-            SelectedDestination = AvailableDestinations.FirstOrDefault();
+            // Devices that only exist in layers.chromatics4: their provider
+            // is off or the hardware is gone, but their saved layers are
+            // still copyable. Names aren't persisted with layers, so the
+            // label is the device type plus a slice of its id.
+            foreach (var group in MappingLayers.GetLayers().Values
+                         .Where(l => l.deviceGuid != Guid.Empty && !_connectedDevices.ContainsKey(l.deviceGuid))
+                         .GroupBy(l => l.deviceGuid))
+            {
+                var sample = group.First();
+                _allDevices.Add(new DeviceItem
+                {
+                    DeviceId = group.Key,
+                    Name = $"{sample.deviceType} {group.Key.ToString("N")[..8]}",
+                    DeviceType = sample.deviceType,
+                    IsPresent = false,
+                });
+            }
+
+            RebuildDeviceList(initialSourceGuid);
+            if (SelectedDestination == null)
+                SelectedDestination = AvailableDestinations.FirstOrDefault();
             RebuildLayerRows();
         }
 
         private readonly IReadOnlyDictionary<Guid, IRGBDevice> _connectedDevices;
+        private readonly List<DeviceItem> _allDevices = new();
+
+        // Rebuilds the visible source list from the master list, honouring
+        // the hide filter and keeping the current selection when it
+        // survives the filter.
+        private void RebuildDeviceList(Guid? preferredGuid = null)
+        {
+            var keep = preferredGuid ?? SelectedSource?.DeviceId;
+            Devices.Clear();
+            foreach (var d in _allDevices)
+            {
+                if (HideUnavailable && (!d.IsPresent || d.IsDisabled)) continue;
+                Devices.Add(d);
+            }
+
+            SelectedSource = Devices.FirstOrDefault(d => d.DeviceId == keep)
+                          ?? Devices.FirstOrDefault();
+        }
+
+        partial void OnHideUnavailableChanged(bool value) => RebuildDeviceList();
 
         public ObservableCollection<DeviceItem> Devices { get; } = new();
         public ObservableCollection<DeviceItem> AvailableDestinations { get; } = new();
@@ -66,6 +105,9 @@ namespace Chromatics.ViewModels
         [ObservableProperty] private string _summaryText;
         [ObservableProperty] private bool _hasNoLayers;
         [ObservableProperty] private bool _canCopy;
+        [ObservableProperty] private bool _hideUnavailable;
+        [ObservableProperty] private bool _sourceUnavailable;
+        [ObservableProperty] private string _sourceUnavailableText;
 
         public void SelectAll()
         {
@@ -84,6 +126,14 @@ namespace Chromatics.ViewModels
 
         partial void OnSelectedSourceChanged(DeviceItem value)
         {
+            SourceUnavailable = value != null && (!value.IsPresent || value.IsDisabled);
+            SourceUnavailableText = value == null ? ""
+                : !value.IsPresent
+                    ? LocalizationService.Instance["This device is not connected. Its saved layers can still be copied."]
+                : value.IsDisabled
+                    ? LocalizationService.Instance["This device is disabled on the Mappings tab. Its saved layers can still be copied."]
+                : "";
+
             RebuildDestinationOptions();
             if (SelectedDestination == null
                 || !AvailableDestinations.Any(d => d.DeviceId == SelectedDestination.DeviceId))
@@ -105,6 +155,9 @@ namespace Chromatics.ViewModels
             foreach (var d in Devices)
             {
                 if (d.DeviceId == SelectedSource.DeviceId) continue;
+                // A destination needs a live IRGBDevice for its LED list;
+                // mappings-file-only devices are sources only.
+                if (!d.IsPresent) continue;
                 if (!LayerCopier.IsCopyAllowed(SelectedSource.DeviceType, d.DeviceType)) continue;
                 AvailableDestinations.Add(d);
             }
@@ -119,7 +172,9 @@ namespace Chromatics.ViewModels
 
             HasNoLayers = false;
             if (SelectedSource == null || SelectedDestination == null) { UpdateSummary(); return; }
-            if (!_connectedDevices.TryGetValue(SelectedSource.DeviceId, out var src)) { UpdateSummary(); return; }
+            // src stays null for a mappings-file-only source; the copy runs
+            // off the layer data alone via the type-based default mapping.
+            _connectedDevices.TryGetValue(SelectedSource.DeviceId, out var src);
             if (!_connectedDevices.TryGetValue(SelectedDestination.DeviceId, out var dst)) { UpdateSummary(); return; }
 
             AvailableDestLedIds.Clear();
@@ -153,7 +208,9 @@ namespace Chromatics.ViewModels
             foreach (var layer in sourceLayers)
             {
                 var usedSourceLedIds = layer.deviceLeds?.Values.Distinct().ToList() ?? new List<LedId>();
-                var defaultMap = LayerCopier.ComputeDefaultMappingForLayer(usedSourceLedIds, src, dst);
+                var defaultMap = src != null
+                    ? LayerCopier.ComputeDefaultMappingForLayer(usedSourceLedIds, src, dst)
+                    : LayerCopier.ComputeDefaultMappingForLayer(usedSourceLedIds, SelectedSource.DeviceType, dst);
 
                 var row = new LayerCopyRow
                 {
@@ -284,7 +341,19 @@ namespace Chromatics.ViewModels
             public Guid DeviceId { get; init; }
             public string Name { get; init; }
             public RGBDeviceType DeviceType { get; init; }
-            public override string ToString() => Name;
+
+            // Present = an IRGBDevice exists right now. A device that only
+            // survives in layers.chromatics4 (provider off, hardware gone)
+            // is a valid copy SOURCE but never a destination.
+            public bool IsPresent { get; init; } = true;
+            public bool IsDisabled { get; init; }
+
+            public string DisplayLabel =>
+                !IsPresent ? $"{Name} ({LocalizationService.Instance["not connected"]})"
+                : IsDisabled ? $"{Name} ({LocalizationService.Instance["disabled"]})"
+                : Name;
+
+            public override string ToString() => DisplayLabel;
         }
 
         public partial class LayerCopyRow : ObservableObject

--- a/Chromatics/ViewModels/SettingsViewModel.cs
+++ b/Chromatics/ViewModels/SettingsViewModel.cs
@@ -59,6 +59,7 @@ namespace Chromatics.ViewModels
             _enableCrashReports = s.enableCrashReports;
             _dynamicLightingBypassConflictCheck = s.dynamicLightingBypassConflictCheck;
             _closeWithGame = s.closeWithGame;
+            _idleRefreshWhenDisconnected = s.idleRefreshWhenDisconnected;
             _globalBrightness = s.globalbrightness;
 
             foreach (var t in Enum.GetValues(typeof(Theme)).Cast<Theme>())
@@ -1189,6 +1190,22 @@ namespace Chromatics.ViewModels
                     var s = AppSettings.GetSettings();
                     s.closeWithGame = value;
                     AppSettings.SaveSettings(s);
+                }
+            }
+        }
+
+        private bool _idleRefreshWhenDisconnected;
+        public bool IdleRefreshWhenDisconnected
+        {
+            get => _idleRefreshWhenDisconnected;
+            set
+            {
+                if (SetProperty(ref _idleRefreshWhenDisconnected, value))
+                {
+                    var s = AppSettings.GetSettings();
+                    s.idleRefreshWhenDisconnected = value;
+                    AppSettings.SaveSettings(s);
+                    RGBController.ReapplyIdleUpdateRate();
                 }
             }
         }

--- a/Chromatics/Views/Dialogs/CopyLayersDialog.axaml
+++ b/Chromatics/Views/Dialogs/CopyLayersDialog.axaml
@@ -17,23 +17,31 @@
                    FontWeight="SemiBold"
                    Margin="0,0,0,6" />
 
-        <TextBlock Grid.Row="1"
-                   Text="{loc:Tr Key='Pick which dynamic layers from the source device to duplicate onto the destination. Base and Effect layers are not copied; they belong to the destination device. New dynamic layers are added without disturbing any that already exist on the destination.'}"
-                   TextWrapping="Wrap"
-                   Opacity="0.8"
-                   Margin="0,0,0,16" />
+        <StackPanel Grid.Row="1" Spacing="8" Margin="0,0,0,16">
+            <TextBlock Text="{loc:Tr Key='Pick which dynamic layers from the source device to duplicate onto the destination. Base and Effect layers are not copied; they belong to the destination device. New dynamic layers are added without disturbing any that already exist on the destination.'}"
+                       TextWrapping="Wrap"
+                       Opacity="0.8" />
+            <CheckBox Content="{loc:Tr Key='Hide devices that are disabled or not connected.'}"
+                      IsChecked="{Binding HideUnavailable, Mode=TwoWay}" />
+        </StackPanel>
 
         <!-- Source device -->
         <Grid Grid.Row="2" ColumnDefinitions="120,*" Margin="0,0,0,8">
             <TextBlock Grid.Column="0"
                        Text="{loc:Tr Key='Source device'}"
-                       VerticalAlignment="Center"
+                       VerticalAlignment="Top"
+                       Margin="0,6,0,0"
                        FontWeight="SemiBold" />
-            <ComboBox Grid.Column="1"
-                      ItemsSource="{Binding Devices}"
-                      SelectedItem="{Binding SelectedSource, Mode=TwoWay}"
-                      DisplayMemberBinding="{Binding Name}"
-                      HorizontalAlignment="Stretch" />
+            <StackPanel Grid.Column="1" Spacing="4">
+                <ComboBox ItemsSource="{Binding Devices}"
+                          SelectedItem="{Binding SelectedSource, Mode=TwoWay}"
+                          DisplayMemberBinding="{Binding DisplayLabel}"
+                          HorizontalAlignment="Stretch" />
+                <TextBlock Text="{Binding SourceUnavailableText}"
+                           IsVisible="{Binding SourceUnavailable}"
+                           TextWrapping="Wrap"
+                           FontStyle="Italic" />
+            </StackPanel>
         </Grid>
 
         <!-- Destination device -->
@@ -48,7 +56,7 @@
             <ComboBox Grid.Column="1"
                       ItemsSource="{Binding AvailableDestinations}"
                       SelectedItem="{Binding SelectedDestination, Mode=TwoWay}"
-                      DisplayMemberBinding="{Binding Name}"
+                      DisplayMemberBinding="{Binding DisplayLabel}"
                       HorizontalAlignment="Stretch" />
         </Grid>
 

--- a/Chromatics/Views/Dialogs/UpdateDialog.axaml.cs
+++ b/Chromatics/Views/Dialogs/UpdateDialog.axaml.cs
@@ -69,12 +69,20 @@ namespace Chromatics.Views.Dialogs
             var sb = new StringBuilder();
             for (int i = 0; i < versions.Count; i++)
             {
-                if (i > 0) sb.AppendLine().AppendLine("---").AppendLine();
+                // TrimNotesToOwnSection keeps each entry to its own bullets:
+                // notes from older publishes carry their own version heading
+                // plus every older section, which doubled the version line
+                // and repeated content across entries.
+                var body = UpdateService.TrimNotesToOwnSection(
+                    versions[i].Notes, versions[i].Version.ToString());
+                if (string.IsNullOrWhiteSpace(body)) continue;
+
+                if (sb.Length > 0) sb.AppendLine().AppendLine("---").AppendLine();
                 sb.Append("## ").AppendLine(versions[i].Version.ToString());
                 sb.AppendLine();
-                sb.AppendLine(versions[i].Notes.Trim());
+                sb.AppendLine(body);
             }
-            return sb.ToString();
+            return sb.Length > 0 ? sb.ToString() : "(No release notes provided.)";
         }
 
         private async void OnInstall(object sender, RoutedEventArgs e)

--- a/Chromatics/Views/NanoleafAdoptionDialog.axaml
+++ b/Chromatics/Views/NanoleafAdoptionDialog.axaml
@@ -70,7 +70,7 @@
 
         <Grid Grid.Row="3" ColumnDefinitions="*,Auto" Margin="0,10,0,0">
             <TextBox Grid.Column="0"
-                     Watermark="{loc:Tr Key='Controller IP address (if not found automatically)'}"
+                     PlaceholderText="{loc:Tr Key='Controller IP address (if not found automatically)'}"
                      Text="{Binding ManualIp, Mode=TwoWay}"
                      Margin="0,0,8,0" />
             <Button Grid.Column="1"

--- a/Chromatics/Views/SettingsView.axaml
+++ b/Chromatics/Views/SettingsView.axaml
@@ -32,6 +32,9 @@
                     <CheckBox Content="{loc:Tr Key='Close Chromatics when FFXIV closes.'}"
                               IsChecked="{Binding CloseWithGame, Mode=TwoWay}"
                               ToolTip.Tip="{loc:Tr Key='Default: Disabled'}" />
+                    <CheckBox Content="{loc:Tr Key='Lower the RGB refresh rate while FFXIV is not running.'}"
+                              IsChecked="{Binding IdleRefreshWhenDisconnected, Mode=TwoWay}"
+                              ToolTip.Tip="{loc:Tr Key='The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled'}" />
                 </StackPanel>
             </HeaderedContentControl>
 

--- a/Chromatics/locale/de.json
+++ b/Chromatics/locale/de.json
@@ -1001,5 +1001,12 @@
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[BETA] Nanoleaf-Smart-Light-Unterstützung aktivieren/deaktivieren. Koppelt Nanoleaf-Controller (Shapes, Canvas, Elements, Lines, Aurora) über Ihr LAN – jeder Controller erfordert eine einmalige Kopplung per Tastendruck. Essentials-Lampen und -Lightstrips werden nicht unterstützt. Standard: Deaktiviert",
   "Pairing failed. Try again.": "Kopplung fehlgeschlagen. Versuchen Sie es erneut.",
   "Pair": "Koppeln",
-  "Remove": "Entfernen"
+  "Remove": "Entfernen",
+  "Lower the RGB refresh rate while FFXIV is not running.": "Die RGB-Aktualisierungsrate verringern, während FFXIV nicht läuft.",
+  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "Die konfigurierte Aktualisierungsrate wird wiederhergestellt, wenn Chromatics sich mit FFXIV verbindet. Standard: Aktiviert",
+  "Hide devices that are disabled or not connected.": "Geräte ausblenden, die deaktiviert oder nicht verbunden sind.",
+  "not connected": "nicht verbunden",
+  "disabled": "deaktiviert",
+  "This device is not connected. Its saved layers can still be copied.": "Dieses Gerät ist nicht verbunden. Seine gespeicherten Ebenen können weiterhin kopiert werden.",
+  "This device is disabled on the Mappings tab. Its saved layers can still be copied.": "Dieses Gerät ist auf der Registerkarte „Zuordnungen“ deaktiviert. Seine gespeicherten Ebenen können weiterhin kopiert werden."
 }

--- a/Chromatics/locale/en.json
+++ b/Chromatics/locale/en.json
@@ -1016,5 +1016,12 @@
     "Remove":  "Remove",
     "Paired - {0} panels":  "Paired - {0} panels",
     "Nanoleaf (Beta)":  "Nanoleaf (Beta)",
-    "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled":  "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled"
+    "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled":  "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled",
+    "Lower the RGB refresh rate while FFXIV is not running.":  "Lower the RGB refresh rate while FFXIV is not running.",
+    "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled":  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled",
+    "Hide devices that are disabled or not connected.":  "Hide devices that are disabled or not connected.",
+    "not connected":  "not connected",
+    "disabled":  "disabled",
+    "This device is not connected. Its saved layers can still be copied.":  "This device is not connected. Its saved layers can still be copied.",
+    "This device is disabled on the Mappings tab. Its saved layers can still be copied.":  "This device is disabled on the Mappings tab. Its saved layers can still be copied."
 }

--- a/Chromatics/locale/es.json
+++ b/Chromatics/locale/es.json
@@ -1000,7 +1000,7 @@
   "Nanoleaf (Beta)": "Nanoleaf (Beta)",
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[BETA] Activa o desactiva la compatibilidad con luces inteligentes Nanoleaf. Empareja controladores Nanoleaf (Shapes, Canvas, Elements, Lines, Aurora) a través de tu red LAN; cada controlador requiere emparejarse una sola vez pulsando un botón. Las bombillas y tiras Essentials no son compatibles. Valor predeterminado: desactivado",
   "Pairing failed. Try again.": "No se pudo emparejar. Inténtalo de nuevo.",
-  "Pair": "Par",
+  "Pair": "Emparejar",
   "Remove": "Eliminar",
   "Lower the RGB refresh rate while FFXIV is not running.": "Reduce la frecuencia de actualización RGB mientras FFXIV no se esté ejecutando.",
   "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "La frecuencia de actualización configurada se reanuda cuando Chromatics se conecta a FFXIV. Predeterminado: activado",

--- a/Chromatics/locale/es.json
+++ b/Chromatics/locale/es.json
@@ -1001,5 +1001,12 @@
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[BETA] Activa o desactiva la compatibilidad con luces inteligentes Nanoleaf. Empareja controladores Nanoleaf (Shapes, Canvas, Elements, Lines, Aurora) a través de tu red LAN; cada controlador requiere emparejarse una sola vez pulsando un botón. Las bombillas y tiras Essentials no son compatibles. Valor predeterminado: desactivado",
   "Pairing failed. Try again.": "No se pudo emparejar. Inténtalo de nuevo.",
   "Pair": "Par",
-  "Remove": "Eliminar"
+  "Remove": "Eliminar",
+  "Lower the RGB refresh rate while FFXIV is not running.": "Reduce la frecuencia de actualización RGB mientras FFXIV no se esté ejecutando.",
+  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "La frecuencia de actualización configurada se reanuda cuando Chromatics se conecta a FFXIV. Predeterminado: activado",
+  "Hide devices that are disabled or not connected.": "Oculta los dispositivos que estén desactivados o no conectados.",
+  "not connected": "no conectado",
+  "disabled": "desactivado",
+  "This device is not connected. Its saved layers can still be copied.": "Este dispositivo no está conectado. Sus capas guardadas aún se pueden copiar.",
+  "This device is disabled on the Mappings tab. Its saved layers can still be copied.": "Este dispositivo está desactivado en la pestaña Asignaciones. Sus capas guardadas aún se pueden copiar."
 }

--- a/Chromatics/locale/fr.json
+++ b/Chromatics/locale/fr.json
@@ -1001,5 +1001,12 @@
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[BÊTA] Active/désactive la prise en charge des éclairages connectés Nanoleaf. Associe les contrôleurs Nanoleaf (Shapes, Canvas, Elements, Lines, Aurora) via votre réseau local ; chaque contrôleur nécessite une association unique par pression sur un bouton. Les ampoules et rubans Essentials ne sont pas pris en charge. Valeur par défaut : désactivé",
   "Pairing failed. Try again.": "Échec de l’appairage. Réessayez.",
   "Pair": "Paire",
-  "Remove": "Supprimer"
+  "Remove": "Supprimer",
+  "Lower the RGB refresh rate while FFXIV is not running.": "Réduire le taux de rafraîchissement RVB lorsque FFXIV n’est pas en cours d’exécution.",
+  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "Le taux de rafraîchissement configuré reprend lorsque Chromatics se connecte à FFXIV. Par défaut : activé",
+  "Hide devices that are disabled or not connected.": "Masquer les périphériques désactivés ou non connectés.",
+  "not connected": "non connecté",
+  "disabled": "désactivé",
+  "This device is not connected. Its saved layers can still be copied.": "Ce périphérique n’est pas connecté. Ses calques enregistrés peuvent toujours être copiés.",
+  "This device is disabled on the Mappings tab. Its saved layers can still be copied.": "Ce périphérique est désactivé dans l’onglet Mappages. Ses calques enregistrés peuvent toujours être copiés."
 }

--- a/Chromatics/locale/fr.json
+++ b/Chromatics/locale/fr.json
@@ -1000,7 +1000,7 @@
   "Nanoleaf (Beta)": "Nanoleaf (bêta)",
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[BÊTA] Active/désactive la prise en charge des éclairages connectés Nanoleaf. Associe les contrôleurs Nanoleaf (Shapes, Canvas, Elements, Lines, Aurora) via votre réseau local ; chaque contrôleur nécessite une association unique par pression sur un bouton. Les ampoules et rubans Essentials ne sont pas pris en charge. Valeur par défaut : désactivé",
   "Pairing failed. Try again.": "Échec de l’appairage. Réessayez.",
-  "Pair": "Paire",
+  "Pair": "Appairer",
   "Remove": "Supprimer",
   "Lower the RGB refresh rate while FFXIV is not running.": "Réduire le taux de rafraîchissement RVB lorsque FFXIV n’est pas en cours d’exécution.",
   "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "Le taux de rafraîchissement configuré reprend lorsque Chromatics se connecte à FFXIV. Par défaut : activé",

--- a/Chromatics/locale/ja.json
+++ b/Chromatics/locale/ja.json
@@ -1002,5 +1002,12 @@
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[ベータ] Nanoleaf スマートライトのサポートを有効/無効にします。LAN 経由で Nanoleaf コントローラー（Shapes、Canvas、Elements、Lines、Aurora）をペアリングします。各コントローラーでは初回のみボタン押下によるペアリングが必要です。Essentials の電球およびライトストリップには対応していません。デフォルト: 無効",
   "Pairing failed. Try again.": "ペアリングに失敗しました。もう一度お試しください。",
   "Pair": "ペア",
-  "Remove": "削除"
+  "Remove": "削除",
+  "Lower the RGB refresh rate while FFXIV is not running.": "FFXIVが実行されていない間、RGBのリフレッシュレートを下げます。",
+  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "ChromaticsがFFXIVに接続すると、設定されたリフレッシュレートに戻ります。デフォルト：有効",
+  "Hide devices that are disabled or not connected.": "無効化されている、または接続されていないデバイスを非表示にします。",
+  "not connected": "未接続",
+  "disabled": "無効",
+  "This device is not connected. Its saved layers can still be copied.": "このデバイスは接続されていません。保存済みのレイヤーは引き続きコピーできます。",
+  "This device is disabled on the Mappings tab. Its saved layers can still be copied.": "このデバイスは「マッピング」タブで無効化されています。保存済みのレイヤーは引き続きコピーできます。"
 }

--- a/Chromatics/locale/ja.json
+++ b/Chromatics/locale/ja.json
@@ -1001,7 +1001,7 @@
   "Nanoleaf (Beta)": "Nanoleaf（ベータ）",
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[ベータ] Nanoleaf スマートライトのサポートを有効/無効にします。LAN 経由で Nanoleaf コントローラー（Shapes、Canvas、Elements、Lines、Aurora）をペアリングします。各コントローラーでは初回のみボタン押下によるペアリングが必要です。Essentials の電球およびライトストリップには対応していません。デフォルト: 無効",
   "Pairing failed. Try again.": "ペアリングに失敗しました。もう一度お試しください。",
-  "Pair": "ペア",
+  "Pair": "ペアリング",
   "Remove": "削除",
   "Lower the RGB refresh rate while FFXIV is not running.": "FFXIVが実行されていない間、RGBのリフレッシュレートを下げます。",
   "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "ChromaticsがFFXIVに接続すると、設定されたリフレッシュレートに戻ります。デフォルト：有効",

--- a/Chromatics/locale/ko.json
+++ b/Chromatics/locale/ko.json
@@ -1002,5 +1002,12 @@
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[베타] Nanoleaf 스마트 조명 지원을 활성화/비활성화합니다. LAN을 통해 Nanoleaf 컨트롤러(Shapes, Canvas, Elements, Lines, Aurora)를 페어링합니다. 각 컨트롤러는 한 번의 버튼 누름 페어링이 필요합니다. Essentials 전구 및 스트립은 지원되지 않습니다. 기본값: 비활성화",
   "Pairing failed. Try again.": "페어링에 실패했습니다. 다시 시도하세요.",
   "Pair": "페어링",
-  "Remove": "제거"
+  "Remove": "제거",
+  "Lower the RGB refresh rate while FFXIV is not running.": "FFXIV가 실행 중이 아닐 때 RGB 새로 고침 빈도를 낮춥니다.",
+  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "Chromatics가 FFXIV에 연결되면 설정된 새로 고침 빈도로 돌아갑니다. 기본값: 활성화됨",
+  "Hide devices that are disabled or not connected.": "비활성화되었거나 연결되지 않은 장치를 숨깁니다.",
+  "not connected": "연결되지 않음",
+  "disabled": "비활성화됨",
+  "This device is not connected. Its saved layers can still be copied.": "이 장치는 연결되어 있지 않습니다. 저장된 레이어는 계속 복사할 수 있습니다.",
+  "This device is disabled on the Mappings tab. Its saved layers can still be copied.": "이 장치는 매핑 탭에서 비활성화되어 있습니다. 저장된 레이어는 계속 복사할 수 있습니다."
 }

--- a/Chromatics/locale/zh_CN.json
+++ b/Chromatics/locale/zh_CN.json
@@ -1001,5 +1001,12 @@
   "[BETA] Enable/disable Nanoleaf smart-light support. Pairs Nanoleaf controllers (Shapes, Canvas, Elements, Lines, Aurora) over your LAN - each controller needs a one-time button-press pairing. Essentials bulbs and strips are not supported. Default: Disabled": "[BETA] 启用/禁用 Nanoleaf 智能灯支持。通过局域网配对 Nanoleaf 控制器（Shapes、Canvas、Elements、Lines、Aurora）——每个控制器都需要一次性按键配对。不支持 Essentials 灯泡和灯带。默认：禁用",
   "Pairing failed. Try again.": "配对失败。请重试。",
   "Pair": "配对",
-  "Remove": "删除"
+  "Remove": "删除",
+  "Lower the RGB refresh rate while FFXIV is not running.": "在 FFXIV 未运行时降低 RGB 刷新率。",
+  "The configured refresh rate resumes when Chromatics attaches to FFXIV. Default: Enabled": "当 Chromatics 连接到 FFXIV 时，将恢复已配置的刷新率。默认：已启用",
+  "Hide devices that are disabled or not connected.": "隐藏已禁用或未连接的设备。",
+  "not connected": "未连接",
+  "disabled": "已禁用",
+  "This device is not connected. Its saved layers can still be copied.": "此设备未连接。仍可复制其已保存的图层。",
+  "This device is disabled on the Mappings tab. Its saved layers can still be copied.": "此设备已在“映射”选项卡中禁用。仍可复制其已保存的图层。"
 }


### PR DESCRIPTION
Two features on top of the 4.3.24 release.

## Lower the RGB refresh rate while FFXIV is not running

New checkbox under Settings → General, on by default. The disconnect throttle already existed: the surface drops to an idle tick rate while the game is not attached and resumes the configured rate on attach. This PR puts it behind a setting so users can turn it off and keep their configured rate at all times, for example when they use Chromatics lighting outside the game. Flipping the toggle applies the rate immediately through a new `RGBController.ReapplyIdleUpdateRate` instead of waiting for the next connect or disconnect.

## Copy layers from disabled and disconnected devices

The copy dialog now lists devices that only exist in layers.chromatics4 (provider off, or hardware gone) as copy sources, alongside devices disabled on the Mappings tab. The picker labels their state - "(disabled)" or "(not connected)" - and a note under the source dropdown tells the user the copy runs from saved layers. A checkbox hides unavailable devices for a shorter list.

Disconnected devices are source-only, since a destination needs live LEDs to map onto. Their default LED mapping comes from a new `LayerCopier.ComputeDefaultMappingForLayer` overload that works from the layer's own key set: identity match for keyboard pairs, ordinal fallback otherwise, with the per-layer mapping expander available to correct any row. Device names are not persisted with layers, so disconnected entries are labelled by device type plus an id slice.

## Notes

- New locale keys shipped in all seven languages.
- chromatics-docs updated separately (Settings and Mappings pages).
- 165/165 xUnit tests pass, including five new tests pinning the default LED mapping rules for disconnected sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
